### PR TITLE
feat: ci

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,11 +18,9 @@ jobs:
     - name: Run compile.sh
       run: |
         chmod +x ./compile.sh 
-        ./compile.sh
-      env:
-        FORCE_VERSION: kr
+        FORCE_VERSION=kr-$(git describe --tags --always) ./compile.sh
     # - name: Upload Artifact
     #   uses: actions/upload-artifact@v2
     #   with:
     #     name: dol-kr
-    #     path: Degrees of Lewdity kr.html
+    #     path: Degrees of Lewdity kr-*.html

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,8 +21,8 @@ jobs:
         sh -c './compile.sh; exit 0' # TODO: Remove exit 0, Upstream build script returns 1 whatever it succeed or not. see !797
       env:
         FORCE_VERSION: kr
-    - name: Upload Artifact
-      uses: actions/upload-artifact@v2
-      with:
-        name: dol-kr
-        path: Degrees of Lewdity kr.html
+    # - name: Upload Artifact
+    #   uses: actions/upload-artifact@v2
+    #   with:
+    #     name: dol-kr
+    #     path: Degrees of Lewdity kr.html

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Run compile.sh
       run: |
         chmod +x ./compile.sh 
-        sh -c './compile.sh; exit 0' # TODO: Remove exit 0, Upstream build script returns 1 whatever it succeed or not. see !797
+        ./compile.sh
       env:
         FORCE_VERSION: kr
     # - name: Upload Artifact

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,20 +7,58 @@ on:
 
 jobs:
   html:
+    name: Build HTML
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repository
       uses: actions/checkout@v2
+
     - name: Get devTools/tweego from original repository
       run: |
         git clone -c core.symlinks=false --depth=1 https://gitgud.io/Vrelnir/degrees-of-lewdity.git _originalRepository
         cp -rf ./_originalRepository/devTools/tweego ./devTools/tweego
+
     - name: Run compile.sh
       run: |
         chmod +x ./compile.sh 
         FORCE_VERSION=kr-$(git describe --tags --always) ./compile.sh
+
     # - name: Upload Artifact
     #   uses: actions/upload-artifact@v2
     #   with:
     #     name: dol-kr
     #     path: Degrees of Lewdity kr-*.html
+
+  debug_apk:
+    name: Build APK (Debug)
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repository
+      uses: actions/checkout@v2
+
+    - name: Get devTools/tweego from original repository
+      run: |
+        git clone -c core.symlinks=false --depth=1 https://gitgud.io/Vrelnir/degrees-of-lewdity.git _originalRepository
+        cp -rf ./_originalRepository/devTools/tweego ./devTools/tweego
+
+    - name: Apply patch for APK build
+      run: |
+        sed -i 's/\"enableLinkNumberify\"\: true/\"enableLinkNumberify\"\: false/g' game/01-config/sugarcubeConfig.js
+        mkdir img
+
+    - name: Run compile.sh
+      run: |
+        chmod +x ./compile.sh 
+        FORCE_VERSION='' ./compile.sh
+
+    - name: Build Cordova docker image
+      run: |
+        cd devTools/androidsdk/image
+        docker build -t cordova-android:latest .
+    - name: Build debug apk
+      run: docker run -v "$GITHUB_WORKSPACE":"/src" -t cordova-android npm run build-debug
+    # - name: Upload Artifact
+    #   uses: actions/upload-artifact@v2
+    #   with:
+    #     name: dol-kr-debug-apk
+    #     path: dist/*-debug.apk

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,28 @@
+name: Build
+
+on:
+  push:
+    branches:
+    - main
+
+jobs:
+  html:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repository
+      uses: actions/checkout@v2
+    - name: Get devTools/tweego from original repository
+      run: |
+        git clone -c core.symlinks=false --depth=1 https://gitgud.io/Vrelnir/degrees-of-lewdity.git _originalRepository
+        cp -rf ./_originalRepository/devTools/tweego ./devTools/tweego
+    - name: Run compile.sh
+      run: |
+        chmod +x ./compile.sh 
+        sh -c './compile.sh; exit 0' # TODO: Remove exit 0, Upstream build script returns 1 whatever it succeed or not. see !797
+      env:
+        FORCE_VERSION: kr
+    - name: Upload Artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: dol-kr
+        path: Degrees of Lewdity kr.html

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,5 +60,5 @@ jobs:
     # - name: Upload Artifact
     #   uses: actions/upload-artifact@v2
     #   with:
-    #     name: dol-kr-debug-apk
+    #     name: dol-kr-debug_apk
     #     path: dist/*-debug.apk

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,11 +2,18 @@ stages:
   - build
 
 default:
+  image: alpine:latest
   before_script:
+    # Install requirements
+    - | 
+      apk update
+      apk add git bash
+
     # Get devTools/tweego from original repository
     - |
       git clone -c core.symlinks=false --depth=1 https://gitgud.io/Vrelnir/degrees-of-lewdity.git _originalRepository
       cp -rf ./_originalRepository/devTools/tweego ./devTools/tweego
+
     # Fix Permission on compile script.
     - chmod +x ./compile.sh 
 
@@ -22,6 +29,9 @@ build:html:
   #     - Degrees of Lewdity kr-*.html
 
 build:debug_apk:
+  image: docker:latest
+  services:
+    - docker:dind
   stage: build
   script:
     # Apply patch for APK build
@@ -41,6 +51,6 @@ build:debug_apk:
     - docker run -v $CI_PROJECT_DIR:/src -t cordova-android npm run build-debug
 
   # artifacts:
-  #   name: dol-kr-debug-apk
+  #   name: dol-kr-debug_apk
   #   paths:
   #     - dist/*-debug.apk

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -17,7 +17,7 @@ build:html:
     - FORCE_VERSION=kr-$(git describe --tags --always) ./compile.sh
 
   # artifacts:
-  #   expose_as: dol-kr
+  #   name: dol-kr
   #   paths:
   #     - Degrees of Lewdity kr-*.html
 
@@ -41,6 +41,6 @@ build:debug_apk:
     - docker run -v $CI_PROJECT_DIR:/src -t cordova-android npm run build-debug
 
   # artifacts:
-  #   expose_as: dol-kr-debug-apk
+  #   name: dol-kr-debug-apk
   #   paths:
   #     - dist/*-debug.apk

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,18 @@
+stages:
+  - build
+
+build:
+  stage: build
+  script:
+    # Get devTools/tweego from original repository
+    - git clone -c core.symlinks=false --depth=1 https://gitgud.io/Vrelnir/degrees-of-lewdity.git _originalRepository
+    - cp -rf ./_originalRepository/devTools/tweego ./devTools/tweego
+
+    # Build
+    - chmod +x ./compile.sh 
+    - FORCE_VERSION=kr sh -c 'bash ./compile.sh; exit 0' # TODO: Remove exit 0, Upstream build script returns 1 whatever it succeed or not. see !797
+
+#  artifacts:
+#    expose_as: dol-kr
+#    paths:
+#      - Degrees of Lewdity kr.html

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,18 +1,46 @@
 stages:
   - build
 
-build:
+default:
+  before_script:
+    # Get devTools/tweego from original repository
+    - |
+      git clone -c core.symlinks=false --depth=1 https://gitgud.io/Vrelnir/degrees-of-lewdity.git _originalRepository
+      cp -rf ./_originalRepository/devTools/tweego ./devTools/tweego
+    # Fix Permission on compile script.
+    - chmod +x ./compile.sh 
+
+build:html:
   stage: build
   script:
-    # Get devTools/tweego from original repository
-    - git clone -c core.symlinks=false --depth=1 https://gitgud.io/Vrelnir/degrees-of-lewdity.git _originalRepository
-    - cp -rf ./_originalRepository/devTools/tweego ./devTools/tweego
-
     # Build
-    - chmod +x ./compile.sh 
     - FORCE_VERSION=kr-$(git describe --tags --always) ./compile.sh
 
   # artifacts:
   #   expose_as: dol-kr
   #   paths:
   #     - Degrees of Lewdity kr-*.html
+
+build:debug_apk:
+  stage: build
+  script:
+    # Apply patch for APK build
+    - |
+      sed -i 's/\"enableLinkNumberify\"\: true/\"enableLinkNumberify\"\: false/g' game/01-config/sugarcubeConfig.js
+      mkdir img
+
+    # Build HTML
+    - FORCE_VERSION='' ./compile.sh
+
+    # Build Cordova docker image
+    - |
+      cd devTools/androidsdk/image
+      docker build -t cordova-android:latest .
+
+    # Build debug apk
+    - docker run -v $CI_PROJECT_DIR:/src -t cordova-android npm run build-debug
+
+  # artifacts:
+  #   expose_as: dol-kr-debug-apk
+  #   paths:
+  #     - dist/*-debug.apk

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,7 +10,7 @@ build:
 
     # Build
     - chmod +x ./compile.sh 
-    - FORCE_VERSION=kr sh -c 'bash ./compile.sh; exit 0' # TODO: Remove exit 0, Upstream build script returns 1 whatever it succeed or not. see !797
+    - FORCE_VERSION=kr ./compile.sh
 
   # artifacts:
   #   expose_as: dol-kr

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -12,7 +12,7 @@ build:
     - chmod +x ./compile.sh 
     - FORCE_VERSION=kr sh -c 'bash ./compile.sh; exit 0' # TODO: Remove exit 0, Upstream build script returns 1 whatever it succeed or not. see !797
 
-#  artifacts:
-#    expose_as: dol-kr
-#    paths:
-#      - Degrees of Lewdity kr.html
+  # artifacts:
+  #   expose_as: dol-kr
+  #   paths:
+  #     - Degrees of Lewdity kr.html

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,9 +10,9 @@ build:
 
     # Build
     - chmod +x ./compile.sh 
-    - FORCE_VERSION=kr ./compile.sh
+    - FORCE_VERSION=kr-$(git describe --tags --always) ./compile.sh
 
   # artifacts:
   #   expose_as: dol-kr
   #   paths:
-  #     - Degrees of Lewdity kr.html
+  #     - Degrees of Lewdity kr-*.html

--- a/compile.sh
+++ b/compile.sh
@@ -63,7 +63,7 @@ function compile() {
 		exit 1
 	else
 		echo "Done: \"$TARGET\""
-		exit 1
+		exit 0
 	fi
 }
 

--- a/devTools/androidsdk/image/cordova/package.json
+++ b/devTools/androidsdk/image/cordova/package.json
@@ -2,7 +2,7 @@
   "name": "degrees-of-lewdity-android-app",
   "version": "0.2.25.0",
   "description": "This sub-project exists to build DoL as an Android app",
-  "main": "Degrees of Lewdity kr.html",
+  "main": "Degrees of Lewdity.html",
   "scripts": {
     "build-debug-ci": "cordova build --debug",
     "build-debug": "npm run update-version && cordova build --debug",

--- a/devTools/androidsdk/image/cordova/platforms/android/app/src/main/AndroidManifest.xml
+++ b/devTools/androidsdk/image/cordova/platforms/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<manifest android:hardwareAccelerated="true" android:versionCode="217" android:versionName="0.2.17-dev" package="com.vrelnir.DegreesOfLewdity" xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest android:hardwareAccelerated="true" android:versionCode="217" android:versionName="0.2.17-dev" package="com.vrelnir.DegreesOfLewdityKr" xmlns:android="http://schemas.android.com/apk/res/android">
     <supports-screens android:anyDensity="true" android:largeScreens="true" android:normalScreens="true" android:resizeable="true" android:smallScreens="true" android:xlargeScreens="true" />
     <uses-permission android:name="android.permission.INTERNET" />
     <application android:hardwareAccelerated="true" android:icon="@mipmap/ic_launcher" android:label="@string/app_name" android:supportsRtl="true">

--- a/devTools/androidsdk/image/cordova/platforms/android/app/src/main/java/com/vrelnir/DegreesOfLewdityKr/MainActivity.java
+++ b/devTools/androidsdk/image/cordova/platforms/android/app/src/main/java/com/vrelnir/DegreesOfLewdityKr/MainActivity.java
@@ -17,14 +17,14 @@
        under the License.
  */
 
-package com.vrelnir.DegreesOfLewdity;
+package com.vrelnir.DegreesOfLewdityKr;
 
 import android.os.Bundle;
 import android.os.SystemClock;
 import android.widget.Toast;
 import org.apache.cordova.*;
 
-import com.vrelnir.DegreesOfLewdity.R;
+import com.vrelnir.DegreesOfLewdityKr.R;
 
 public class MainActivity extends CordovaActivity {
 

--- a/devTools/androidsdk/image/cordova/platforms/android/app/src/main/res/xml/config.xml
+++ b/devTools/androidsdk/image/cordova/platforms/android/app/src/main/res/xml/config.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<widget android-packageName="com.vrelnir.DegreesOfLewdity" id="dol" version="0.2.17-dev" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+<widget android-packageName="com.vrelnir.DegreesOfLewdityKr" id="dol" version="0.2.17-dev" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
     <name short="DoL">Degrees of Lewdity</name>
     <description>Degrees of Lewdity</description>
     <author email="9096-Vrelnir@users.noreply.gitgud.io" href="https://gitgud.io/Vrelnir/degrees-of-lewdity">

--- a/devTools/androidsdk/image/cordova/scripts/copyGameFiles.js
+++ b/devTools/androidsdk/image/cordova/scripts/copyGameFiles.js
@@ -9,7 +9,7 @@ if (fs.existsSync(path.resolve(ROOT, 'img'))) {
 }
 
 function copyFilesFromRoot() {
-    const MAIN = 'Degrees of Lewdity kr.html'
+    const MAIN = 'Degrees of Lewdity.html'
     const ANDROID_PATH = path.resolve('./platforms/android/app/src/main/assets/www')
     const paths = {
         src: {


### PR DESCRIPTION
자동으로 결과물을 build하는 스크립트입니다.
GitHub Actions를 사용하였으며, Gitlab 기반으로 이주가 필요할시 사용할 수 있는 `.gitlab-ci.yml`도 같이 포함하였습니다.

빌드된 결과물 업로드는 비활성화 해뒀습니다. 각 CI 파일에서 주석 처리한 부분을 다시 활성화 시키면 됩니다.

현재 GitHub Actions의 한계로 default branch에 ci 파일이 있어야만 작동합니다.
또한 main으로 push된 상황에서만 작동되도록 설정해놨습니다.

기존 메인테이너분이 부재이신걸로 보여서 여기에 PR을 올립니다.

추가: apk 빌드도 추가했습니다. 기본 빌드 및 apk 빌드 둘다 img는 제외된채로 빌드됩니다. 테스트 빌드 시스템으로 알아주세요.