### PR TITLE
ci: fix versioning on apk

### DIFF
--- a/devTools/androidsdk/image/cordova/scripts/copyForDist.js
+++ b/devTools/androidsdk/image/cordova/scripts/copyForDist.js
@@ -11,15 +11,13 @@ function copyFilesToRoot() {
     const OUTPUT_ROOT = path.resolve("platforms/android/app/build/outputs/apk/");
     const DIST_ROOT = path.resolve(ROOT, 'dist')
     let version = fs.readFileSync(path.resolve(ROOT, 'version'));
-	try {
-		let version_ko = fs.readFileSync(path.resolve(ROOT, 'version.ko'));
-		version = version + "-" + version_ko;	// OriginalVersion-KoVersion
-	}
-	catch(err)
-	{
-		;	// original version only
-	}
-	
+    try {
+        let version_ko = fs.readFileSync(path.resolve(ROOT, 'version.ko'));
+        version = version + "-" + version_ko;   // OriginalVersion-KoVersion
+    } catch(err) {
+        ;   // original version only
+    }
+
     const paths = {
         android: {
             src: {

--- a/devTools/androidsdk/image/cordova/scripts/updateVersion.js
+++ b/devTools/androidsdk/image/cordova/scripts/updateVersion.js
@@ -12,6 +12,12 @@ if (!version) {
         process.exit(1)
     }
     version = fs.readFileSync(versionFile).toString();
+    try {
+        let version_ko = fs.readFileSync(path.resolve(SRC, 'version.ko'));
+        version = version + "-" + version_ko;   // OriginalVersion-KoVersion
+    } catch(err) {
+        ;   // original version only
+    }
 } else {
     console.log(`Updating to version number "${version}"`)
 }


### PR DESCRIPTION
기존 파일형식이랑 같게 코드를 정렬 했습니다.
복사되는 파일만 버전코드가 추가되는점을 고쳐, 실제 APK버전도 변경됩니다.
