### PR TITLE
overworld-forest/loc-lake 남은 3개 파일 번역

### DIFF
--- a/game/overworld-forest/loc-lake/mason.twee
+++ b/game/overworld-forest/loc-lake/mason.twee
@@ -1,15 +1,15 @@
 :: Lake Mason Intro
 <<effects>>
 <<npc Mason>><<person1>>
-You swim into the middle of the lake. There Mason swims in a wide circle. <<He>> notices you approach, and faces you, treading water.
+당신은 호수 한가운데로 헤엄쳐 들어간다. 수영 선생님 메이슨이 넓은 원을 그리며 수영을 하고 있다. <<He_nun>> 당신이 다가온 것을 알아차리고, 그 자리에서 멈춰 당신을 바라본다.
 <br><br>
 
-"It's nice to see you out here," <<he>> says. "If it's okay though, I'd like to continue my laps." <<He>> swims away before you can get close.
+"여기서 보니 반갑구나." <<he_ga>> 말했다. "그럼 난 마저 한 바퀴 더 돌러 가볼게." <<He_nun>> 당신이 가까이 가기도 전에 헤엄쳐 가버린다.
 <br><br>
 
-<<link [[Try to catch them (0:05)|Lake Mason Swim]]>><<tiredness 1>><</link>><<swimmingdifficulty 1 300>><<gtiredness>>
+<<link [[그를 잡는다 (0:05)|Lake Mason Swim]]>><<tiredness 1>><</link>><<swimmingdifficulty 1 300>><<gtiredness>>
 <br>
-<<link [[Leave|Lake Depths]]>><<endevent>><</link>>
+<<link [[떠난다|Lake Depths]]>><<endevent>><</link>>
 <br>
 
 :: Lake Mason Swim
@@ -17,61 +17,61 @@ You swim into the middle of the lake. There Mason swims in a wide circle. <<He>>
 
 <<if $swimmingskill gte 1000>>
 	<<set $mason_count to 1>>
-	You swim after <<him>>, <span class="green">and manage to close the distance.</span> <<He>> glances over <<his>> shoulder, and swims faster, but still you manage to keep up. You're almost close enough to touch <<him>> when <<he>> stops and turns.
+	당신은 <<him_ul>> 따라 수영한다. <span class="green">가까스로 그와 거리를 좁혔다.</span> <<He_nun>> <<his_yi>> 어깨너머를 슬쩍 보더니 더 빨리 헤엄치기 시작했으나, 당신은 점점 그와 거리를 좁힌다. <<he_ga>> 멈춰 뒤돌았을 때는 이미 당신이 충분히 <<him_ul>> 만질 수 있을만큼 가까이 있었다. 
 	<br><br>
 
-	"I-I see someone's been paying attention in class," <<he>> says. <<He>> holds <<his>> arms beneath the water in a strange way, close to <<his>> body. "If only the rest of the class were so capable. We'd have our own swim team."
+	"수, 수업 시간에 열심히 참여했나보구나." <<he_ga>> 말했다. <<he_ga>> <<his_yi>> 팔을 물 밑에서 이상한 자세로 잡았다. 팔이 어색하게 <<his_yi>> 몸에 가까이 붙어있다. "다른 반 아이들이 너처럼 능력이 있다면, 우리 학교에도 수영팀이 있었을 거야."
 	<br><br>
 
-	You look down, through the rain-broken water, and see the reason for <<his>> behaviour. <span class="lewd"><<Hes>> naked.</span> Something in your expression gives you away, and <<his>> face turns a deep shade of red.
+	당신이 빗줄기 사이로 물 밑을 들여다보면서 <<his_yi>> 행동이 어색했던 이유를 알아챈다. <span class="lewd"><<He_nun>> 아무것도 입고 있지 않았다.</span> 당신의 표정이 어떤 변화를 드러내자, <<his_yi>> 얼굴이 빨갛게 익는다.
 	<br><br>
 
-	"I-I," <<he>> begins, voice quivering. "I prefer swimming like this. It's just more fun."
+	"나-나는..." <<he_ga>> 목소리를 떨며 입을 연다. "나는 이렇게 수영하는게 더 좋아. ...그냥 더 재밌거든."
 	<br><br>
 
-	<<link [[Pretend you haven't noticed|Lake Mason Pretend]]>><<npcincr Mason love 1>><</link>><<glove>>
+	<<link [[모르는 척 한다|Lake Mason Pretend]]>><<npcincr Mason love 1>><</link>><<glove>>
 	<br>
-	<<link [[Tease|Lake Mason Tease]]>><<npcincr Mason love -1>><<npcincr Mason lust 1>><<npcincr Mason dom -1>><</link>><<llove>><<glust>><<promiscuous1>>
+	<<link [[놀린다|Lake Mason Tease]]>><<npcincr Mason love -1>><<npcincr Mason lust 1>><<npcincr Mason dom -1>><</link>><<llove>><<glust>><<promiscuous1>>
 	<br>
-	<<link [[Act nonchalant|Lake Mason Nonchalant]]>><</link>>
+	<<link [[태연하게 행동한다|Lake Mason Nonchalant]]>><</link>>
 	<br>
 
 <<elseif $swimmingskill gte random(1, 300)>>
 	<<set $mason_count to 1>>
-	You swim after <<him>>, but <<hes>> too fast. You'd need to be pretty skilled to match <<him>>, let alone catch up.
+	당신은 <<him_ul>> 따라 수영한다. 그러나 <<he_nun>> 너무 빠르다. <<him_gwa>> 경기하는 건 고사하고 따라잡기라도 하려면 수영을 더 연습해야할 것이다.
 	<br><br>
 
-	You try to head <<him>> off, but <<he>> swims in unexpected directions. It's as if <<hes>> avoiding you.
+	당신은 <<him_ul>> 막아보지만, <<he_nun>> 예상치 못한 방향으로 헤엄쳐 도망간다. <<he_nun>> 당신을 피하는 것 같다.
 	<br><br>
 
-	<span class="green">You have an idea.</span> You dive beneath the water and hold your breath, right in Mason's path. You wait for <<his>> shimmer to appear in the murk, then emerge from the water. <<He>> almost collides with you.
+	<span class="green">당신은 좋은 생각이 떠올랐다.</span> 메이슨이 지나가는 길의 물 밑으로 잠수해서 숨을 참는다. 당신은 흐릿한 물 속에서 <<his_ga>> 다가오길 기다리며 물 밖으로 나가려 준비한다. <<he_ga>> 당신과 부딪힐 뻔 한다.
 	<br><br>
 
-	"I-I didn't expect to see a student out here," <<he>> says as you wipe water from your eyes. <<He>> holds <<his>> arms beneath the water in a strange way, close to <<his>> body. "Though I'm glad to see you practising outside school hours."
+	"여, 여기서 학생을 보게 될 줄은 몰랐는데.." <<he_ga>> 눈가에 묻은 물을 닦아내며 말한다. <<he_ga>> <<his_yi>> 팔을 물 밑에서 이상한 자세로 잡았다. 팔이 어색하게 <<his_yi>> 몸에 가까이 붙어있다. "네가 학교 밖에서 연습하는 걸 보니 기쁘긴 하네."
 	<br><br>
 
-	You look down, through the rain-broken water, and see the reason for <<his>> behaviour. <span class="lewd"><<Hes>> naked.</span> Something in your expression gives you away, and <<his>> face turns a deep shade of red.
+	당신이 빗줄기 사이로 물 밑을 들여다보면서 <<his_yi>> 행동이 어색했던 이유를 알아챈다. <span class="lewd"><<He_nun>> 아무것도 입고 있지 않았다.</span> 당신의 표정이 어떤 변화를 드러내자, <<his_yi>> 얼굴이 빨갛게 익는다.
 	<br><br>
 
-	"I-I," <<he>> begins, voice quivering. "I prefer swimming like this. It's just more fun."
+	"나-나는..." <<he_ga>> 목소리를 떨며 입을 연다. "나는 이렇게 수영하는게 더 좋아. ...그냥 더 재밌거든."
 	<br><br>
 
-	<<link [[Pretend you haven't noticed|Lake Mason Pretend]]>><<npcincr Mason love 1>><</link>><<glove>>
+	<<link [[모르는 척 한다|Lake Mason Pretend]]>><<npcincr Mason love 1>><</link>><<glove>>
 	<br>
-	<<link [[Tease|Lake Mason Tease]]>><<npcincr Mason love -1>><<npcincr Mason lust 1>><<npcincr Mason dom -1>><</link>><<llove>><<glust>><<promiscuous1>>
+	<<link [[놀린다|Lake Mason Tease]]>><<npcincr Mason love -1>><<npcincr Mason lust 1>><<npcincr Mason dom -1>><</link>><<llove>><<glust>><<promiscuous1>>
 	<br>
-	<<link [[Act nonchalant|Lake Mason Nonchalant]]>><</link>>
+	<<link [[태연하게 행동한다|Lake Mason Nonchalant]]>><</link>>
 	<br>
 
 <<else>>
 
-	You swim after <<him>>, <span class="red">but <<hes>> too fast.</span> You'd need to be pretty skilled to match <<him>>, let alone catch up.
+	당신은 <<him_ul>> 따라 수영한다. <span class="red">그러나 <<he_nun>> 너무 빠르다.</span> <<him_gwa>> 경기하는 건 고사하고 따라잡기라도 하려면 수영을 더 연습해야할 것이다.
 	<br><br>
 
-	You try to head <<him>> off, but <<he>> swims in unexpected directions. It's as if <<hes>> avoiding you.
+	당신은 <<him_ul>> 막아보지만, <<he_nun>> 예상치 못한 방향으로 헤엄쳐 도망간다. <<he_nun>> 당신을 피하는 것 같다.
 	<br><br>
 
-	<<link [[Next|Lake Depths]]>><<endevent>><</link>>
+	<<link [[다음|Lake Depths]]>><<endevent>><</link>>
 	<br>
 
 <</if>>
@@ -79,21 +79,21 @@ You swim into the middle of the lake. There Mason swims in a wide circle. <<He>>
 :: Lake Mason Pretend
 <<effects>>
 
-You smile at <<him>>, and try to look confused.
+당신은 <<him_ul>> 보고 웃으며, 혼란스러운 표정을 짓는다.
 
 <<if $submissive gte 1150>>
-	"In the rain?" you say. "I like it too."
+	"비 맞으면서 수영하세요?" 당신이 말한다. "저도 좋아해요."
 <<elseif $submissive lte 850>>
-	"Swimming in the rain isn't that weird," you say. "I like it myself. It's bracing."
+	"빗 속에서 수영하는 건 이상할게 없죠." 당신이 말한다. "저도 좋아해요. 상쾌하거든요."
 <<else>>
-	"Don't worry," you say. "I like swimming in the rain too."
+	"걱정마세요." 당신이 말한다. "저도 빗 속에서 수영하는 건 좋아하거든요."
 <</if>>
 <br><br>
 
-<<He>> looks confused for just a moment. "Th-thank you for understanding," <<he>> says, still covering <<himself>> beneath the water. "I need to get back to my laps. Keep practising, you've shown promising skill."
+<<He_nun>> 잠시 혼란스러워 한다. "이- 이해해줘 고맙구나." 여전히 <<himself>> 물 밑에서 몸을 가리면서 <<he_ga>> 말한다. "내가 돌던 곳으로 돌아가야겠다. 계속 연습하렴, 너는 가능성이 충분하구나."
 <br><br>
 
-<<link [[Next|Lake Depths]]>><<endevent>><</link>>
+<<link [[다음|Lake Depths]]>><<endevent>><</link>>
 <br>
 
 :: Lake Mason Tease
@@ -101,30 +101,30 @@ You smile at <<him>>, and try to look confused.
 
 <<if $exposed gte 2>>
 	<<if $submissive gte 1150>>
-		"Please don't be embarrassed," you giggle. "I'm naked too."
+		"당황하지 마세요." 당신이 피식 웃었다. "저도 똑같아요."
 	<<elseif $submissive lte 850>>
-		"You've nothing to be shy about," you say. "I'm not wearing anything either."
+		"부끄러워 하시지 않아도 돼요." 당신이 말한다. "저도 아무것도 안 입었어요."
 	<<else>>
-		"Don't be shy," you say. "You're not the only one swimming naked."
+		"부끄러워 마세요." 당신이 말한다. "선생님만 알몸으로 수영하는 건 아니니까요."
 	<</if>>
 <<promiscuity1>>
 
-You didn't think it possible, but <<his>> blush deepens. <<He>> looks away, and opens <<his>> mouth to speak. Instead, you get a good look at <<his>> toned ass near the surface of the water as <<he>> turns and swims away.
+당신은 그게 통할 거라 생각하지 않았으나, <<his_yi>> 얼굴이 새빨개진다. <<he_ga>> 시선을 돌리며 <<his_yi>> 입을 연다. <<he_ga>>가 말하려다 말곤 몸을 돌려 헤엄쳐 달아나는 동안, 당신은 수면 가까이에서 <<his_yi>> 탄탄한 엉덩이를 본다.
 <<else>>
 	<<if $submissive gte 1150>>
-		"Please don't be embarrassed," you say. "You know swimming best."
+		"당황하지 마세요." 당신이 말한다. "선생님이 수영은 제일 잘 하잖아요."
 	<<elseif $submissive lte 850>>
-		"You've nothing to be shy about," you say. "I'd show off too if I had a body like that."
+		"부끄러워 하시지 않아도 돼요." 당신이 말한다.. "제가 그런 몸매라면 자랑할 걸요?"
 	<<else>>
-		"Don't be shy," you say. "You look good."
+		"부끄러워 마세요." 당신이 말한다. "정말 멋져 보여요."
 	<</if>>
 <<promiscuity1>>
 
-You didn't think it possible, but <<his>> blush deepens. "I-I need to return to my laps," <<he>> says. You get a good look at <<his>> toned ass near the surface of the water as <<he>> turns and swims away.
+당신은 그게 통할 거라 생각하지 않았으나, <<his_yi>> 얼굴이 새빨개진다. "내-내가 돌던 곳으로 돌아가야겠구나." <<he_ga>> 말한다. <<he_ga>> 몸을 돌려 헤엄쳐 달아나는 동안, 당신은 수면 가까이에서 <<his_yi>> 탄탄한 엉덩이를 본다.
 <</if>>
 <br><br>
 
-<<link [[Next|Lake Depths]]>><<endevent>><</link>>
+<<link [[다음|Lake Depths]]>><<endevent>><</link>>
 <br>
 
 :: Lake Mason Nonchalant
@@ -133,26 +133,26 @@ You didn't think it possible, but <<his>> blush deepens. "I-I need to return to 
 You ignore <<his>> bashfulness.
 <<if $exposed gte 2>>
 	<<if $submissive gte 1150>>
-		"Me too," you say. "I'm naked right now."
+		"저도에요." 당신이 말한다. "지금 아무것도 안 입고 있어요."
 	<<elseif $submissive lte 850>>
-		"I get it," you say. "That's why I'm naked."
+		"대충 이해해요." 당신이 말한다. "저도 그래서 알몸이잖아요?"
 	<<else>>
-		"I know what you mean," you say. "I'm naked too."
+		"무슨 말인지 알겠어요." 당신이 말한다. "저도 안 입었으니까요."
 	<</if>>
-	You didn't think it possible, but <<his>> blush deepens. "I-I need to return to my laps," <<he>> says. You get a good look at <<his>> toned ass near the surface of the water as <<he>> turns and swims away.
+	당신은 그게 통할 거라 생각하지 않았으나, <<his_yi>> 얼굴이 새빨개진다. "내-내가 돌던 곳으로 돌아가야겠구나." <<he_ga>> 말한다. <<he_ga>> 몸을 돌려 헤엄쳐 달아나는 동안, 당신은 수면 가까이에서 <<his_yi>> 탄탄한 엉덩이를 본다.
 <<else>>
 	<<if $submissive gte 1150>>
-		"I-it's fine," you say. "Lots of people do it."
+		"그, 그럴 수도 있죠. 당신이 말한다. "많은 사람들이 하니까요."
 	<<elseif $submissive lte 850>>
-		"It's fine," you say. "Not like anyone would find out anyway. Except me, but I'm great."
+		"괜찮아요." 당신이 말한다. "어차피 아무도 알아채지 못할거에요. 저만 빼고요. 전 괜찮아요."
 	<<else>>
-		"Don't worry," you say. "That isn't strange."
+		"걱정마세요." 당신이 말한다. "이상한건 아니니까요."
 	<</if>>
-	<<He>> seems relieved by your words, but doesn't move <<his>> arms. "I-I need to return to my laps," <<he>> says. You get a good look at <<his>> toned ass near the surface of the water as <<he>> turns and swims away.
+	<<He_nun>> 당신의 말에 안도했지만, <<his_yi>> 팔을 치우지는 않는다. "내-내가 돌던 곳으로 돌아가야겠구나." <<he_ga>> 말한다. <<he_ga>> 몸을 돌려 헤엄쳐 달아나는 동안, 당신은 수면 가까이에서 <<his_yi>> 탄탄한 엉덩이를 본다.
 <</if>>
 <br><br>
 
-<<link [[Next|Lake Depths]]>><<endevent>><</link>>
+<<link [[다음|Lake Depths]]>><<endevent>><</link>>
 <br>
 
 :: Lake Mason
@@ -160,20 +160,20 @@ You ignore <<his>> bashfulness.
 
 <<npc Mason>><<person1>>
 
-You swim towards Mason. <<He>> doesn't try to outswim you, and starts treading water as you draw close. <<He>> covers <<his>> toned body beneath the water.
+당신은 메이슨을 향해 헤엄쳐 간다. <<He_nun>> 도망치지 않고 당신이 다가오자 제자리에서 천천히 발을 움직인다. <<He_nun>> <<his_yi>> 탄탄한 그의 몸을 물 밑에서 감춘다.
 <br><br>
 
-"C-can I help you?" <<he>> asks, eager to return to <<his>> laps.
+"무, 무슨 일이니?" <<he_ga>> 물었다. 그는 <<his_ga>> 돌던 곳으로 돌아가고 싶어한다. 
 <br><br>
 
-<<link [[Just say Hello|Lake Mason Greet]]>><<stress -6>><</link>><<lstress>>
+<<link [[인사한다|Lake Mason Greet]]>><<stress -6>><</link>><<lstress>>
 <br>
 <<if $mason_count lte 1>>
-	<<link [[Ask to chat|Lake Mason Ask]]>><<npcincr Mason love 1>><</link>><<glove>>
+	<<link [[잡담을 나누자고 한다|Lake Mason Ask]]>><<npcincr Mason love 1>><</link>><<glove>>
 	<br>
 <</if>>
 <<if $promiscuity gte 15>>
-	<<link [[Ask to see|Lake Mason Flirt]]>><<npcincr Mason love -1>><<npcincr Mason lust 1>><<npcincr Mason dom -1>><</link>><<promiscuous2>><<llove>><<glust>>
+	<<link [[보고 싶다고 한다|Lake Mason Flirt]]>><<npcincr Mason love -1>><<npcincr Mason lust 1>><<npcincr Mason dom -1>><</link>><<promiscuous2>><<llove>><<glust>>
 	<br>
 <</if>>
 
@@ -181,114 +181,114 @@ You swim towards Mason. <<He>> doesn't try to outswim you, and starts treading w
 <<effects>>
 
 <<set $mason_count to 2>>
-You ask Mason if <<hes>> free to talk. <<He>> glances beneath the water. "N-not right now," <<he>> says. "But there's a place nearby I go to relax in the evening, after my swim. You can find me there if you want to talk."
+당신은 <<he_wa>> 이야기하고 싶다고 말한다. <<He_nun>> 물 밑을 바라본다. "지-지금은 말고.." <<he_ga>> 말한다. "이 근처에 수영 끝나고 저녁에 휴식을 취하는 곳이 있어. 얘기하고 싶으면 거기서 날 찾으렴."
 <br><br>
 
-<span class="gold"><<He>> gives you directions to <<his>> secret spot near the waterfall. <<He>> will be there on rainy non-school evenings.</span>
+<span class="gold"><<he_ga>> 당신에게 폭포 근처에 있는 <<his_yi>> 비밀 장소를 알려준다. <<He_nun>> 학교에 가지 않는 날, 저녁 시간에 그 곳에 있을 것이다.</span>
 <br><br>
 
-<<link [[Next|Lake Depths]]>><<endevent>><</link>>
+<<link [[다음|Lake Depths]]>><<endevent>><</link>>
 <br>
 
 :: Lake Mason Greet
 <<effects>>
 
-You exchange awkward pleasantries. <<He>> remains covered and blushing the whole time, before returning to <<his>> laps. You get a nice look at <<his>> toned ass near the surface of the water as <<he>> swims away.
+당신은 어색한 인삿말을 주고 받는다. <<He_nun>> <<his_yi>> 장소로 돌아가기 전까지 계속 얼굴을 붉히고 몸을 가린다. <<he_ga>> 몸을 돌려 헤엄쳐 달아나는 동안, 당신은 수면 가까이에서 <<his_yi>> 탄탄한 엉덩이를 본다.
 <br><br>
 
-<<link [[Next|Lake Depths]]>><<endevent>><</link>>
+<<link [[다음|Lake Depths]]>><<endevent>><</link>>
 <br>
 
 :: Lake Mason Flirt
 <<effects>>
 
 <<if $submissive gte 1150>>
-	"I-I don't mean to be rude," you say. "But can I see? No one will know."
+	"무, 무례하게 굴려는 건 아니지만.." 당신이 말한다. "제가 좀 볼 수 있을까요? 아무도 모를 거에요."
 <<elseif $submissive lte 850>>
-	"Don't be coy," you say. "You want people to see. You've got a good body, it's only natural you'd want to show it off. So show me."
+	"내숭떨지 마세요." 당신이 말한다. "사람들이 봤으면 하는 거 아니에요? 몸매가 좋으시네요. 자랑하고 싶은 건 당연하잖아요. 그러니까 보여주실래요?"
 <<else>>
-	"Let me see," you say. "No one will know."
+	"어디 봐요." 당신이 말한다. "잠깐 보면 아무도 모를거에요."
 <</if>>
 <br><br>
 
 <<if $NPCName[$NPCNameList.indexOf("Mason")].lust gte 10>>
 	<<earnFeat "Mason's Secret">>
-	<<He>> blushes. "F-Fine," <<he>> says, voice quivering with anger as much as embarrassment. "If that's what it'll take to get you to stop bothering me."
+	<<he_ga>> 뺨을 붉힌다. "조-좋아." 당황한 만큼이나 분노로 떨리는 목소리로 <<he_ga>> 말한다. "그, 그러고 나면 더는 귀찮게 굴지 말아야 한다?"
 	<br><br>
 
-	<<He>> hesitates despite <<his>> words, then slowly moves <<his>> arms aside. You dive under the water for a better look at <<his>> sleek and toned body.
+	<<He_nun>> <<he_ga>> 말하고도 망설이더니 천천히 <<his_yi>> 팔을 치운다. 당신은 <<his_yi>> 매끈하고 탄탄한 몸매를 더 잘 보기 위해 물속으로 잠수한다.
 
 	<<if $pronoun is "f">>
 		<<if $NPCList[0].penis isnot "none">>
-			Your eyes are drawn to <<his>> <span class="lewd"><<print $NPCList[0].breastsdesc>> and <<print $NPCList[0].penisdesc>>.</span> You're used to seeing their contours beneath <<his>> tight swimsuit, but seeing them exposed in the water is something else.
+			당신의 시선이 <<his_yi>> <span class="lewd"><<print $NPCList[0].breastsdesc_wa>> <<print $NPCList[0].penisdesc_ro>> 이끌린다.</span> 당신은 몸의 윤곽을 드러내는 <<his_yi>> 딱 붙는 수영복에는 익숙했지만, 물 속에서 노출된 모습을 보는 것에는 또 다른 느낌을 받는다.
 		<<else>>
-			Your eyes are drawn to <<his>> <span class="lewd"><<print $NPCList[0].breastsdesc>>.</span> You're used to seeing their contours beneath <<his>> tight swimsuit, but seeing them exposed in the water is something else.
+			당신의 시선이 <<his_yi>> <span class="lewd"><<print $NPCList[0].breastsdesc_ro>> 이끌린다.</span> 당신은 몸의 윤곽을 드러내는 <<his_yi>> 딱 붙는 수영복에는 익숙했지만, 물 속에서 노출된 모습을 보는 것에는 또 다른 느낌을 받는다.
 		<</if>>
 	<<else>>
 		<<if $NPCList[0].penis isnot "none">>
-			Your eyes are drawn to <<his>> <span class="lewd"><<print $NPCList[0].penisdesc>>.</span> You're used to seeing its contours beneath <<his>> tight swimsuit, but seeing it exposed in the water is something else.
+			당신의 시선이 <<his_yi>> <span class="lewd"><<print $NPCList[0].penisdescPost "에">> 닿았다.</span> 당신은 몸의 윤곽을 드러내는 <<his_yi>> 딱 붙는 수영복에는 익숙했지만, 물 속에서 노출된 모습을 보는 것에는 또 다른 느낌을 받는다.
 		<<else>>
-			Your eyes are drawn to <<his>> <span class="lewd">pussy.</span> You're used to seeing its contours beneath <<his>> tight swimsuit, but seeing it exposed in the water is something else.
+			당신의 시선이 <<his_yi>> <span class="lewd"> 음부에 닿았다.</span> 당신은 몸의 윤곽을 드러내는 <<his_yi>> 딱 붙는 수영복에는 익숙했지만, 물 속에서 노출된 모습을 보는 것에는 또 다른 느낌을 받는다.
 		<</if>>
 	<</if>>
 	<br><br>
 
-	<<He>> covers <<himself>> again when you come up for air. "I-I hope you're satisfied," <<he>> says. "Now leave me to finish my laps in peace." <<He>> turn and swims away.
+	<<He_nun>> <<himself>> 당신이 바깥으로 나올 때마다 몸을 가린다. "네- 네가 만족했길 바라는구나." <<he_ga>> 말한다. "이제 내가 편안하게 한 바퀴 돌게 내버려두렴." <<He_nun>> 뒤돌아서 헤엄쳐 가버린다.
 	<br><br>
 
-	<<link [[Next|Lake Depths]]>><<endevent>><</link>>
+	<<link [[다음|Lake Depths]]>><<endevent>><</link>>
 	<br>
 
 <<else>>
-	<<He>> blushes. "Th-that's no request to make of your teacher!" <<he>> says. "Now please, let me get back to my laps." You get a nice look at <<his>> toned ass near the surface of the water as <<he>> swims away.
+	<<he_ga>> 뺨을 붉힌다. "선생님한테 할 부탁이 아니잖니!" <<he_ga>> 말한다. "이제 날 내버려두렴." <<he_ga>> 몸을 돌려 헤엄쳐 달아나는 동안, 당신은 수면 가까이에서 <<his_yi>> 탄탄한 엉덩이를 본다.
 	<br><br>
 
-	<<link [[Next|Lake Depths]]>><<endevent>><</link>>
+	<<link [[다음|Lake Depths]]>><<endevent>><</link>>
 	<br>
 <</if>>
 
 :: Mason Pond
 <<set $location to "lake">><<set $outside to 1>><<effects>>
 
-You follow one of the streams feeding the lake, to the pond Mason likes to relax in. Water bubbles up from a spring beneath it.
+호수에 흐르는 물줄기를 따라 올라가면 메이슨이 쉬기 좋아하는 연못으로 갈 수 있다. 그 밑에 있는 샘에서 거품이 일어난다.
 <br><br>
 <<if $schoolday isnot 1 and $weather is "rain" and $daystate is "dusk">>
-	<<npc Mason>><<person1>>Mason sits in it, wearing a swimsuit. <<His>> arms rest on the rocky bank, and <<his>> eyes are shut.
+	<<npc Mason>><<person1>>메이슨이 수영복을 입고 그 안에 앉아있다. <<his_yi>> 팔은 바위 둑에 얹혀 있고, <<his_yi>> 눈은 감겨 있다.
 	<br><br>
 
 	<<if $exposed gte 2>>
 		<<if $exhibitionism gte 75>>
-			<<link [[Sit in the pond|Mason In Pond Naked]]>><</link>><<if $ex_mason isnot 1>><<exhibitionist5>><</if>>
+			<<link [[연못 안에 앉는다|Mason In Pond Naked]]>><</link>><<if $ex_mason isnot 1>><<exhibitionist5>><</if>>
 			<br>
-			<<link [[Sit beside the pond|Mason Beside Pond Naked]]>><</link>><<if $ex_mason isnot 1>><<exhibitionist5>><</if>>
+			<<link [[연못가에 앉는다|Mason Beside Pond Naked]]>><</link>><<if $ex_mason isnot 1>><<exhibitionist5>><</if>>
 			<br>
 		<<else>>
-			<<covered>> You couldn't alert Mason to your presence like this!
+			<<covered>> 메이슨에게 이런 식으로 당신의 존재를 알려서는 안된다!
 			<br><br>
 		<</if>>
 	<<elseif $exposed gte 1>>
 		<<if $exhibitionism gte 35>>
-			<<link [[Sit in the pond|Mason In Pond Naked]]>><</link>><<if $ex_mason isnot 1>><<exhibitionist3>><</if>>
+			<<link [[연못 안에 앉는다|Mason In Pond Naked]]>><</link>><<if $ex_mason isnot 1>><<exhibitionist3>><</if>>
 			<br>
-			<<link [[Sit beside the pond|Mason Beside Pond Naked]]>><</link>><<if $ex_mason isnot 1>><<exhibitionist3>><</if>>
+			<<link [[연못가에 앉는다|Mason Beside Pond Naked]]>><</link>><<if $ex_mason isnot 1>><<exhibitionist3>><</if>>
 			<br>
 		<<else>>
-			<<covered>> You couldn't alert Mason to your presence like this!
+			<<covered>> 메이슨에게 이런 식으로 당신의 존재를 알려서는 안된다!
 			<br><br>
 		<</if>>
 	<<else>>
-		<<link [[Sit in the pond|Mason In Pond]]>><</link>>
+		<<link [[연못 안에 앉는다|Mason In Pond]]>><</link>>
 		<br>
-		<<link [[Sit beside the pond|Mason Beside Pond]]>><</link>>
+		<<link [[연못가에 앉는다|Mason Beside Pond]]>><</link>>
 		<br>
 	<</if>>
-	<<link [[Leave|Lake Waterfall]]>><<endevent>><</link>>
+	<<link [[떠난다|Lake Waterfall]]>><<endevent>><</link>>
 	<br>
 <<else>>
-	The pond is empty. Mason likes to come here on rainy evenings on weekends and school holidays, after swimming in the lake.
+	연못은 비었다. 메이슨은 비가 오는 주말과 휴일 저녁에 호수에서 수영을 즐긴 후에 이 곳에 올 것이다. 
 	<br><br>
 
-	<<link [[Leave|Lake Waterfall]]>><</link>>
+	<<link [[떠난다|Lake Waterfall]]>><</link>>
 	<br>
 <</if>>
 
@@ -297,7 +297,7 @@ You follow one of the streams feeding the lake, to the pond Mason likes to relax
 
 <<if $mason_count gte 3>>
 
-	You sit beside the pond. Mason opens <<his>> eyes when <<he>> hears you.
+	당신은 연못가에 앉는다. <<he_ga>> 당신의 기척을 느끼자, <<his_yi>> 눈을 떴다.
 	<br><br>
 
 	<<mason_greet>>
@@ -307,13 +307,13 @@ You follow one of the streams feeding the lake, to the pond Mason likes to relax
 
 <<else>><<set $mason_count to 3>>
 	<<swim_check>>
-	You sit beside the pond. Mason opens <<his>> eyes when <<he>> hears you.
+	당신은 연못가에 앉는다. <<he_ga>> 당신의 기척을 느끼자, <<his_yi>> 눈을 떴다.
 	<br><br>
 
 	<<if _swim_check is 1>>
-		"I'm glad you found me," <<he>> says. "You can get in if you like."
+		"여기까지 찾아와주다니 고맙구나." <<he_ga>> 말한다. "원한다면 들어와도 좋아."
 	<<else>>
-		"I'm glad you found me," <<he>> says. "You can get in if you like. There's a little hidey hole at the shore of the lake if you need somewhere to keep your clothes."
+		"여기까지 찾아와주다니 고맙구나." <<he_ga>> 말한다. "원한다면 들어와도 좋아. 호수 기슭에 옷을 보관할 수 있는 작은 구멍이 있어."
 	<</if>>
 	<br><br>
 
@@ -326,7 +326,7 @@ You follow one of the streams feeding the lake, to the pond Mason likes to relax
 
 <<if $mason_count gte 3>>
 
-	You slip into the pond opposite Mason. <<His>> eyes open when <<he>> hears the splash.
+	당신은 메이슨 맞은편 연못으로 들어간다. <<he_ga>> 물이 튀기는 소리에, <<his_yi>> 눈을 떴다.
 	<br><br>
 
 	<<mason_greet>>
@@ -336,13 +336,13 @@ You follow one of the streams feeding the lake, to the pond Mason likes to relax
 
 <<else>><<set $mason_count to 3>>
 	<<swim_check>>
-	You slip into the pond opposite Mason. <<His>> eyes open when <<he>> hears the splash.
+	당신은 메이슨 맞은편 연못으로 들어간다. <<he_ga>> 물이 튀기는 소리에, <<his_yi>> 눈을 떴다.
 	<br><br>
 
 	<<if _swim_check is 1>>
-		"I'm glad you found me," <<he>> says. "The water here is lovely, and it's so secluded."
+		"여기까지 찾아와주다니 고맙구나." <<he_ga>> 말한다. "여긴 적당히 한적하고 물이 엄청 좋지."
 	<<else>>
-		"I'm glad you found me," <<he>> says. "The water here is lovely, and it's so secluded." <<He>> looks at your clothes. "You've got your clothes all wet! There's a little hidey hole at the shore of the lake if you need somewhere to keep them in the future."
+		"여기까지 찾아와주다니 고맙구나." <<he_ga>> 말한다. "여긴 적당히 한적하고 물이 엄청 좋지." <<he_ga>> 당신의 옷을 본다. "옷이 다 젖었잖아! 호수 기슭에 옷을 보관할 수 있는 작은 구멍이 있어, 다음번에 필요하면 거길 이용하렴."
 	<</if>>
 	<br><br>
 
@@ -353,7 +353,7 @@ You follow one of the streams feeding the lake, to the pond Mason likes to relax
 :: Mason Beside Pond Naked
 <<effects>>
 
-<<flaunting>> you sit beside the pond. Mason opens <<his>> eyes when <<he>> hears you, but shuts them again when <<he>> sees your <<lewdness>>.
+<<flaunting>> 당신은 연못가에 앉는다. <<he_ga>> 당신의 기척을 느끼자, <<his_yi>> 눈을 떴다. 그러나 금방 당신의 <<lewdness>> 때문에 <<he_ga>> 눈을 감는다. 
 <<if $exposed gte 2>>
 	<<if $ex_mason isnot 1>>
 		<<exhibitionism5>>
@@ -379,7 +379,7 @@ You follow one of the streams feeding the lake, to the pond Mason likes to relax
 
 <<else>><<set $mason_count to 3>>
 
-	"I-I'm glad you found me here," <<he>> says. "But could you put some clothes on?"
+	"여, 여기까지 찾아와주다니 고맙구나." <<he_ga>> 말한다. "하지만 옷 좀 입어 주겠니?"
 	<br><br>
 
 	<<mason_actions>>
@@ -389,7 +389,7 @@ You follow one of the streams feeding the lake, to the pond Mason likes to relax
 :: Mason In Pond Naked
 <<effects>><<water>>
 
-<<flaunting>> you slip into the pond. Mason opens <<his>> eyes when <<he>> hears the splash, but shuts them again when <<he>> sees your <<lewdness>>.
+<<flaunting>> 당신은 메이슨 맞은편 연못으로 들어간다. <<he_ga>> 물이 튀기는 소리에, <<his_yi>> 눈을 떴다. 그러나 금방 당신의 <<lewdness>> 때문에 <<he_ga>> 눈을 감는다. 
 <<if $exposed gte 2>>
 	<<if $ex_mason isnot 1>>
 		<<exhibitionism5>>
@@ -415,7 +415,7 @@ You follow one of the streams feeding the lake, to the pond Mason likes to relax
 
 <<else>><<set $mason_count to 3>>
 
-	"I-I'm glad you found me here," <<he>> says. "But could you put some clothes on?"
+	"여, 여기까지 찾아와주다니 고맙구나." <<he_ga>> 말한다. "하지만 옷 좀 입어 주겠니?"
 	<br><br>
 
 	<<mason_actions>>
@@ -425,22 +425,22 @@ You follow one of the streams feeding the lake, to the pond Mason likes to relax
 :: Mason Pond Chat
 <<effects>>
 
-You chat with Mason.
+당신은 메이슨과 잡담을 나눴다.
 
 <<if $rng gte 81>>
-	<<He>> talks about the lake and the forest surrounding it. It seems they're a big reason <<he>> moved here.
+	<<he_ga>> 호수와 호수를 감싼 숲에 대해 이야기한다. <<he_ga>> 이 동네로 온 가장 큰 이유같이 보인다.
 <<elseif $rng gte 61>>
-	<<He>> asks about school, and probes you for what the other students think of <<him>>.
+	<<he_ga>> 학교에 대해서 묻더니, 이내 당신과 다른 학생들이 <<him_ul>> 어떻게 생각하는지 조사한다.
 <<elseif $rng gte 41>>
-	<<He>> talks about <<his>> successes in competitive swimming.
+	<<He_nun>> 수영 대회에서의 <<his_yi>> 성공에 대해 열변한다.
 <<elseif $rng gte 21>>
-	<<He>> talks about the computer games <<hes>> played recently.
+	<<he_ga>> 최근에 하고 있는 컴퓨터 게임에 대해 말한다. <<he_nun>> 즐거워 보인다.
 <<else>>
-	<<He>> talks about the other teachers. <<Hes>> careful not to insult any of them.
+	<<he_ga>> 다른 선생님들에 대해 말한다. <<He_nun>> 그들을 좋게 말하고자 노력한다.
 <</if>>
 <br><br>
 <<if $swimmingskill lte 999 and random(1, 3) is 3>>
-	<<He>> explains some of <<his>> swimming technique to you. <<swimmingskilluse>>
+	<<He_nun>> <<his_yi>> 수영 기술에 대해 설명한다. <<swimmingskilluse>>
 <</if>>
 
 <<mason_actions>>
@@ -449,10 +449,10 @@ You chat with Mason.
 <<effects>>
 
 <<if $exposed gte 1>>
-	You chat with Mason, and draw attention to your exposed body. <<He>> tries not to look, but glances over occasionally regardless. <<He>> seems uncomfortable.
+	당신은 메이슨과 수다를 떨면서 노출된 신체에 주의를 집중한다. <<He_nun>> 보지 않으려고 애쓰지만, 이따금씩 훑어본다. <<He_nun>> 불편해 보인다.
 
 <<else>>
-	You chat with Mason, and keep commenting about how nice <<his>> body looks. <<He>> looks uncomfortable, and covers <<his>> swimsuit with <<his>> hands as if naked.
+	당신은 메이슨과 수다를 떨면서 <<his_yi>> 몸매가 얼마나 멋진지에 대해 중간중간 칭찬한다. <<He_nun>> 불편해 보이고, <<his_yi>> 수영복을 마치 벌거벗은 것처럼 <<his_yi>> 손으로 가린다.
 
 <</if>>
 <<promiscuity1>>
@@ -462,15 +462,15 @@ You chat with Mason.
 :: Mason Walk
 <<effects>>
 <<dry>><<towelup>><<set $foresthunt to 0>>
-Mason gives you some towels to dry with, and wraps one around <<himself>>. Together you walk
+메이슨은 당신에게 물기를 말릴 수건을 몇 장 건네주고, <<himself>> 몸에 감싼다. 같이 걸어서
 <<if $masonDressed is true>>
-	to where you hid your clothes, then after getting dressed, continue
+	옷을 숨겨 놓은 곳으로 간다. 옷을 갈아입고서
 	<<unset $masonDressed>>
 <</if>>
-through the dark forest in the direction of town.
+어둑해진 숲을 지나 도시로 향한다.
 <br><br>
 
-You arrive on Danube Street without incident. Mason insists on walking you up to the orphanage before waving you goodbye.
+당신은 다누베 거리에 아무런 사고 없이 무사히 도착했다. 메이슨이 고아원 앞까지 바래다주고 손을 흔들며 떠난다.
 <br><br>
 
 <<link [[Next|Domus Street]]>><<set $eventskip to 1>><<endevent>><</link>>
@@ -480,31 +480,31 @@ You arrive on Danube Street without incident. Mason insists on walking you up to
 <<effects>>
 
 <<if $submissive gte 1150>>
-	"I don't want to be a bother," you say. "I'll be okay."
+	"짐이 되고 싶진 않아요." 당신은 말한다. "저는 괜찮아요."
 <<elseif $submissive lte 850>>
-	"Do I look like I'm afraid of the dark?" you ask. "I'll be fine."
+	"제가 어둠을 무서워 할 것 같아요?" 당신이 물었다. "저는 그런거 안무서워요. 괜찮아요."
 <<else>>
-	"It's okay," you say. "I know my way around the forest."
+	"음, 괜찮아요." 당신은 말한다. "제가 숲길을 잘 알거든요."
 <</if>>
 <br><br>
 
-Mason seems unsure, but nods. "If you're sure. Be careful." <<He>> dries <<himself>> with a towel as <<he>> walks into the forest.
+메이슨을 내키지는 않아 보이지만 고개를 끄덕인다. "네가 그렇다면야, 조심히 들어가라." <<He_nun>> <<himself>> <<he_ga>> 숲으로 걸어가며 수건으로 몸을 말린다.
 <br><br>
 
-<<link [[Next|Lake Waterfall]]>><<endevent>><</link>>
+<<link [[다음|Lake Waterfall]]>><<endevent>><</link>>
 <br>
 
 :: Widgets Mason [widget]
 <<widget "mason_actions">>
 <<if $mason_pond is undefined and $NPCName[$NPCNameList.indexOf("Mason")].love gte 30>>
 	<<set $mason_pond to 1>>
-	"There's a lot of water underground around here," Mason says. "There's a stream beneath Domus Street, in fact. I've always wanted to own a home there. I could make my own spring."
+	"이 주변은 지하에 물이 많이 흐른단다." 메이슨이 말한다. "도무스 거리 아래 쪽에 개울리 있는데, 난 항상 거기에 집을 갖고 싶었어. 나만의 샘을 만들 수 있을 것 같아서."
 	<br><br>
-	<<He>> sits up with a splash, and looks at you. "You live on Domus Street, right?" <<he>> asks. <<He>> sits back in the water. "It would be expensive. And you'd need permission from your caretaker. It's fun to think about though."
+	<<he_ga>> 물을 튀기며 앉고서, 당신을 쳐다본다. "너 도무스거리에 살지 않니?" <<he_ga>> 물었다. <<He_nun>> 물 속에 몸을 담궜다. "비싸겠지. 그리고 넌 네 고아원장님께도 허락을 받아야 할거야. 그냥 상상해보는 것도 재밌네."
 	<br><br>
 <</if>>
 <<if $daystate is "night">>
-	The last of the sun's light fades between the leaves. Mason stands up. "We'll catch a chill if we're out here too long," <<he>> says. "The forest can be dangerous after dark. Let me walk you home."
+	어렴풋하던 태양빛의 끝자락이 잎사귀 사이에서 희미하게 사라진다. 메이슨이 일어났다. "여기 너무 오래 있으면 감기에 걸릴 거야." <<he_ga>> 말한다. "어두워지면 숲은 위험할 수 있으니 내가 데려다주마."
 	<br><br>
 
 	<<for _e to 0; _e lt $clothing_number; _e++>>
@@ -518,50 +518,50 @@ Mason seems unsure, but nods. "If you're sure. Be careful." <<He>> dries <<himse
 	<</for>>
 
 	<<if _temp_clothes_present is 1>>
-		<<link [[Get Changed, then walk home with Mason (0:40)|Mason Walk]]>><<pass 40>><<storeon "lakeshore">><<set $masonDressed to true>><</link>>
+		<<link [[옷을 갈아입고 메이슨과 집으로 간다] (0:40)|Mason Walk]]>><<pass 40>><<storeon "lakeshore">><<set $masonDressed to true>><</link>>
 		<br>
 	<</if>>
 
-	<<link [[Walk home with Mason (0:30)|Mason Walk]]>><<pass 30>><</link>>
+	<<link [[메이슨과 집으로 간다 (0:30)|Mason Walk]]>><<pass 30>><</link>>
 	<br>
-	<<link [[Say you'll be okay|Mason Walk Refuse]]>><</link>>
+	<<link [[혼자 가겠다고 말한다|Mason Walk Refuse]]>><</link>>
 	<br>
 
 <<else>>
-	<<link [[Chat (0:30)|Mason Pond Chat]]>><<npcincr Mason love 1>><<pass 30>><<stress -6>><</link>><<glove>><<lstress>>
+	<<link [[잡담한다 (0:30)|Mason Pond Chat]]>><<npcincr Mason love 1>><<pass 30>><<stress -6>><</link>><<glove>><<lstress>>
 	<br>
-	<<link [[Flirt (0:30)|Mason Pond Flirt]]>><<pass 30>><<npcincr Mason love -1>><<npcincr Mason lust 1>><</link>><<promiscuous1>><<llove>><<glust>>
+	<<link [[추파를 던진다 (0:30)|Mason Pond Flirt]]>><<pass 30>><<npcincr Mason love -1>><<npcincr Mason lust 1>><</link>><<promiscuous1>><<llove>><<glust>>
 	<br>
-	<<link [[Leave|Lake Waterfall]]>><<endevent>><</link>>
+	<<link [[떠난다|Lake Waterfall]]>><<endevent>><</link>>
 	<br>
 <</if>>
 <</widget>>
 
 <<widget "mason_greet">>
 <<if $NPCName[$NPCNameList.indexOf("Mason")].love gte 30>>
-	"It's good to see you," <<he>> says, smiling. "I like the company."
+	"널 보니 좋구나." <<he_ga>> 웃으며 말한다. "난 손님을 좋아하는 편이지."
 <<elseif $NPCName[$NPCNameList.indexOf("Mason")].love gte 10>>
-	"I was hoping to see you," <<he>> says.
+	"널 만나길 바랐는데!" <<he_ga>> 말한다.
 <<elseif $NPCName[$NPCNameList.indexOf("Mason")].love gte -10>>
-	"Hey," <<he>> says.
+	"이봐." <<he_ga>> 말한다.
 <<elseif $NPCName[$NPCNameList.indexOf("Mason")].love gte -30>>
-	"What do you want?" <<he>> asks.
+	"무슨 일이니." <<he>> asks.
 <<else>>
-	"Please don't disturb me," <<he>> says.
+	"제발 날 방해하지 마렴." <<he_ga>> 말한다.
 <</if>>
 <</widget>>
 
 <<widget "mason_greet_lust">>
 <<if $NPCName[$NPCNameList.indexOf("Mason")].lust gte 30>>
-	"P-please put some clothes on," <<he>> says, shifting as if to conceal something.
+	"제, 제발 옷 좀 입으렴.." <<he_ga>> 말한다. 메이슨이 뭔가 감추듯 움직인다.
 <<elseif $NPCName[$NPCNameList.indexOf("Mason")].lust gte 10>>
-	"You should put some clothes on," <<he>> says. "People might get the wrong idea if they catch us."
+	"옷을 챙겨입는게 어떠니?" <<he_ga>> 말한다. "우리가 잡히면 사람들이 오해할지도 몰라."
 <<elseif $NPCName[$NPCNameList.indexOf("Mason")].lust gte -10>>
-	"You should put some clothes on," <<he>> says.
+	"넌 옷을 잘 챙겨입어야겠구나." <<he_ga>> 말한다.
 <<elseif $NPCName[$NPCNameList.indexOf("Mason")].lust gte -30>>
-	"That's no way to present yourself to your teacher." <<he>> asks.
+	"선생님에게 널 소개할 올바른 방법이 아니지 않니?." <<he>> 물었다.
 <<else>>
-	<<He>> sighs in resignation.
+	<<he_ga>> 체념하곤 한숨을 쉰다.
 <</if>>
 <</widget>>
 
@@ -569,38 +569,38 @@ Mason seems unsure, but nods. "If you're sure. Be careful." <<He>> dries <<himse
 <<effects>>
 
 <<if $submissive gte 1150>>
-	"D-don't be worried," you say. "I'll be careful."
+	"걱, 걱정마세요." 당신은 말한다. "조심할게요."
 <<elseif $submissive lte 850>>
-	"I can look after myself," you say. "It's warmer down there than up here, anyway."
+	"제 앞가림은 할 줄 알아요." 당신은 말한다. "어쨌든 여기보다 아래가 더 따뜻하니까요."
 <<else>>
-	"Don't worry about me," you say. "I'll be careful."
+	"제 걱정은 안하셔도 돼요." 당신은 말한다. "조심할게요."
 <</if>>
 <br><br>
 <<if $swimmingSuccess>>
 	<<set $mason_ice_lake to 2>>
-	Mason watches you a moment, <span class="green">then sighs in resignation.</span>
+	메이슨이 잠시 당신을 응시한다. <span class="green">그러다 체념하곤 한숨을 쉰다.</span>
 
 	<<if $worn.upper.type.includes("diving") and $worn.lower.type.includes("diving")>>
-		"At least you're dressed for it," <<he>> says. "Just be careful, alright?"
+		"적어도 옷은 입었으니까.." <<he_ga>> 말한다. "정말 조심해야한다, 알겠지?"
 	<<else>>
-		"At least dress properly for it," <<he>> says. "They sell diving gear in town."
+		"옷이라도 제대로 입으렴." <<he_ga>> 말한다. "시내에서 다이빙 장비도 파니까, 응?"
 	<</if>>
-	<<He>> swings <<his>> legs over the hole in the ice, and drops beneath.<<glove>><<npcincr Mason love 1>>
+	<<He_nun>> <<his_yi>> 다리를 다시 빙판의 구멍으로 향하고 물 속으로 들어간다. <<glove>><<npcincr Mason love 1>>
 	<br><br>
 
-	<<link [[Next|Lake Depths Ice]]>><<endevent>><<set $eventskip to 1>><</link>>
+	<<link [[다음|Lake Depths Ice]]>><<endevent>><<set $eventskip to 1>><</link>>
 	<br>
 <<else>>
-	Mason watches you a moment, <span class="red">then shakes <<his>> head.</span>
+	메이슨이 잠시 당신을 응시한다. <span class="red">그러다 굳은 얼굴로 <<his_yi>> 고개를 저었다.</span>
 	<<if $worn.upper.type.includes("diving") and $worn.lower.type.includes("diving")>>
-		"You might be dressed for it," <<he>> says. "But the ice is treacherous."
+		"적어도 옷은 입었으니까.." <<he_ga>> 말한다. "하지만 얼음이 있는 호수는 위험하단다."
 	<<else>>
-		"You don't even have proper diving gear," <<he>> says. "You'll freeze."
+		"다이빙 장비도 제대로 안 갖췄잖니." <<he_ga>> 말한다. "몸이 얼거야."
 	<</if>>
-	<<He>> swings <<his>> legs over the hole in the ice, and drops beneath.<<llove>><<npcincr Mason love -1>>
+	<<He_nun>> <<his_yi>> 다리를 다시 빙판의 구멍으로 향하고 물 속으로 들어간다. <<llove>><<npcincr Mason love -1>>
 	<br><br>
 
-	<<link [[Next|Lake Depths Ice]]>><<endevent>><<set $eventskip to 1>><</link>>
+	<<link [[다음|Lake Depths Ice]]>><<endevent>><<set $eventskip to 1>><</link>>
 	<br>
 <</if>>
 
@@ -609,35 +609,35 @@ Mason seems unsure, but nods. "If you're sure. Be careful." <<He>> dries <<himse
 <<effects>>
 
 <<if $submissive gte 1150>>
-	You thank Mason, avoiding eye contact.
+	당신은 메이슨의 눈을 피하며 감사를 표했다.
 <<elseif $submissive lte 850>>
-	You thank Mason.
+	당신은 메이슨에게 감사를 표했다.
 <<else>>
-	You thank Mason.
+	당신은 메이슨에게 감사를 표했다.
 <</if>>
 
-<<He>> smiles. "No problem," <<he>> says, swinging <<his>> legs over the hole in the ice. "Go get yourself warmed up." <<He>> disappears into the water.
+<<he_ga>> 미소지었다. "당연한 걸, 뭐." <<he_ga>> 말한다. <<his_yi>> 다리를 다시 빙판의 구멍으로 향하고 물 속으로 들어간다. "가서 몸 좀 녹여." <<He_nun>> 깊은 물 속으로 사라졌다.
 <br><br>
 
-<<link [[Next|Lake Depths Ice]]>><<endevent>><<set $eventskip to 1>><</link>>
+<<link [[다음|Lake Depths Ice]]>><<endevent>><<set $eventskip to 1>><</link>>
 <br>
 
 :: Lake Mason Angry
 <<effects>>
 
 <<if $submissive gte 1150>>
-	"I-I was down there on purpose," you say.
+	"저, 저는 다 알아서 내려간 건데.." 당신은 말한다.
 <<elseif $submissive lte 850>>
-	"Don't interfere with my business," you say.
+	"제 일에 간섭하지 마세요." 당신은 말한다.
 <<else>>
-	"I was down there on purpose," you say.
+	"저도 알고서 내려간 거에요." 당신은 말한다.
 <</if>>
 <br><br>
 
-Mason shakes <<his>> head. "I can't be negligent," <<he>> says. "I don't care if you don't appreciate that. Keep working hard in class, and someday you'll be an accomplished enough diver." <<He>> swings <<his>> legs over the hole in the ice, and disappears below the water.
+메이슨이 <<his_yi>> 고개를 내저었다. "이런 일은 유하게 넘어갈 생각없어." <<he_ga>> 말한다. "네가 그걸 고마워하지 않아도 상관없어. 수업 중에 열심히 공부하면 언젠가 충분히 뛰어난 다이버가 될 거야." <<He_nun>> <<his_yi>> 다리를 다시 빙판의 구멍으로 향하고 물 속으로 들어간다. 그리곤 깊은 물 속으로 사라졌다.
 <br><br>
 
-<<link [[Next|Lake Depths Ice]]>><<endevent>><<set $eventskip to 1>><</link>>
+<<link [[다음|Lake Depths Ice]]>><<endevent>><<set $eventskip to 1>><</link>>
 <br>
 
 

--- a/game/overworld-forest/loc-lake/skating.twee
+++ b/game/overworld-forest/loc-lake/skating.twee
@@ -1,38 +1,38 @@
 :: Lake Skate
 <<effects>>
 
-You don a pair of ice skates, and push yourself onto the lake.
+당신은 스케이트를 신고 호수 위로 올라간다.
 
 <<if $danceskill gte 1000>>
-	You glide across, leaping and spinning with grace.
+	당신은 미끄러지듯 움직이고 도약하며 우아하게 돌아 착지한다.
 	<<if $laketeenspresent is 1 and $rng gte 51>>
-		<span class="green">The teenagers watch, awed by your skill.</span><<ltrauma>><<gcool>><<trauma -6>><<status 1>>
+		<span class="green">10대들이 당신의 솜씨에 경외심을 느끼며 지켜본다.</span><<ltrauma>><<gcool>><<trauma -6>><<status 1>>
 	<</if>>
 <<elseif $danceskill gte 800>>
-	You glide across at a good pace, and practise more advanced tricks.
+	당신은 빠른 속도로 미끄러지듯 지나가고, 더 발전된 묘기를 연습한다.
 	<<if $laketeenspresent is 1 and $rng gte 81>>
-		<span class="green">The teenagers watch, awed by your skill.</span><<ltrauma>><<gcool>><<trauma -6>><<status 1>>
+		<span class="green">10대들이 당신의 솜씨에 경외심을 느끼며 지켜본다.</span><<ltrauma>><<gcool>><<trauma -6>><<status 1>>
 	<</if>>
 <<elseif $danceskill gte 600>>
-	You glide across at a good pace.
+	당신은 빠른 속도로 미끄러지듯 지나간다.
 <<elseif $danceskill gte 400>>
-	You move at a good pace, and rarely wobble.
+	당신은 빠른 속도로 미끄러지듯 움직이고, 흔들리지는 않는다.
 <<elseif $danceskill gte 200>>
-	You're a bit wobbly, but manage to put one foot in front of the other without falling.
+	당신은 약간 흔들렸지만, 넘어지지 않고 한쪽 발을 다른 쪽 발 앞에 올려놓는다.
 <<elseif $danceskill gte 100>>
-	You're able to remain upright, but little more than that.
+	당신은 똑바로 설 수 있지만 그 이상은 할 수 없다.
 <<else>>
-	You struggle to even remain upright.<<gpain>><<pain 4>>
+	당신은 적어도 똑바로 서려고 애쓴다.<<gpain>><<pain 4>>
 	<br><br>
 
 	<<if $laketeenspresent is 1>>
 		<<if $cool gte random(1, 400)>>
 			<<generatey1>><<person1>>
-			The other students giggle, but are sympathetic. You're far from the only one struggling. A <<person1>><<person>> lends an arm to steady you.<<gdanceskill>>
+			다른 학생들은 낄낄대지만 호의적인 웃음이다. 그러나 당신만 힘들어하고 있는 것은 아니다. <<person1>><<person_i>> 당신이 균형을 잡을 수 있게 팔을 빌려준다.<<gdanceskill>>
 		<<elseif random(1, 400) gte $cool>>
-			The other students laugh at your expense.<<gtrauma>><<gstress>><<lcool>><<status -10>><<ltrauma>><<lstress>>
+			다른 학생들이 당신의 스케이트가 낭비라고 비웃는다.<<gtrauma>><<gstress>><<lcool>><<status -10>><<ltrauma>><<lstress>>
 		<<else>>
-			The other students giggle, but are sympathetic. You're far from the only one struggling.
+			다른 학생들은 낄낄대지만 호의적인 웃음이다. 그러나 당신만 힘들어하고 있는 것은 아니다.
 		<</if>>
 	<</if>>
 <</if>>
@@ -45,130 +45,130 @@ You don a pair of ice skates, and push yourself onto the lake.
 <<if $danger gte (9900 - $allure) and $laketeenspresent is 1>>
 	<<if $rng gte 81>>
 		<<generatey1>><<person1>>
-		A <<person>> skates by. <<He>> spins as <<he>> passes, and winks. <<Hes>> trying to show off.
+		<<person_i>> 스케이트를 타고 지나간다. <<He_ga>> 지나가면서 빙글 돌고, <<He_ga>> 윙크를 날린다. <<He_nun>> 잘날 척 하려는 듯이 보인다.
 		<br><br>
 
-		<<link [[Challenge (0:05)|Lake Skate Challenge]]>><<pass 5>><</link>><<dancedifficulty 200 1000>>
+		<<link [[경쟁한다 (0:05)|Lake Skate Challenge]]>><<pass 5>><</link>><<dancedifficulty 200 1000>>
 		<br>
-		<<link [[Ignore|Lake Shallows Ice]]>><<endevent>><</link>>
+		<<link [[무시한다|Lake Shallows Ice]]>><<endevent>><</link>>
 		<br>
 
 	<<elseif $rng gte 61>>
-		You catch a <<generatey1>><<person1>><<person>> admiring you from the shore. <<He>> looks away when your eyes meet <<his>>.
+		당신은 호숫가에서 당신을 칭찬하던 <<generatey1>><<person1>><<person_ul>> 마주친다. <<He_ga>> 당신의 눈과 <<his_yi>> 눈이 마주칠 때마다 피한다.
 		<br><br>
 
-		<<link [[Bring onto the ice (0:05)|Lake Skate Flirt]]>><<pass 5>><</link>><<promiscuous1>>
+		<<link [[빙판 위로 데려온다 (0:05)|Lake Skate Flirt]]>><<pass 5>><</link>><<promiscuous1>>
 		<br>
-		<<link [[Ignore|Lake Shallows Ice]]>><<endevent>><</link>>
+		<<link [[무시한다|Lake Shallows Ice]]>><<endevent>><</link>>
 		<br>
 	<<elseif $rng gte 41>>
 		<<generatey1>><<person1>>
-		A <<person>> skates up to you, and wraps <<his>> arms around you from behind. <<He>> licks your ear.<<gtrauma>><<gstress>><<trauma 6>><<stress 6>>
+		<<person_i>> 당신에게 스케이트를 타고 다가와 <<his_yi>> 팔로 당신을 뒤에서 끌어안는다. <<He_ga>> 당신의 귀 끝을 할짝인다.<<gtrauma>><<gstress>><<trauma 6>><<stress 6>>
 		<br><br>
 
-		<<link [[Shove|Lake Skate Shove]]>><<ltrauma>><<def 1>><</link>>
+		<<link [[밀친다|Lake Skate Shove]]>><<ltrauma>><<def 1>><</link>>
 		<br>
-		<<link [[Endure|Lake Skate Endure]]>><<stress 6>><<arousal 600>><</link>><<gstress>><<garousal>>
+		<<link [[참는다|Lake Skate Endure]]>><<stress 6>><<arousal 600>><</link>><<gstress>><<garousal>>
 		<br>
 	<<elseif $rng gte 21>>
 		<<generatey1>><<person1>>
 		<<dancedifficulty 400 1000 true>>
 		<<if $danceSuccess>>
-			A <<person>> wobbles as <<he>> skates up to you. "C-could you teach me how to skate as well as you?"
+			<<person_i>> 비틀거리면서 당신에게 스케이트를 타고 온다. <<He_ga>> 말한다. "스, 스케이트 잘타는 법 좀 가르쳐 줄 수 있어?"
 			<br><br>
 
-			<<link [[Teach (0:20)|Lake Skate Teach]]>><<trauma -6>><<pass 20>><</link>><<ltrauma>>
+			<<link [[가르쳐 준다 (0:20)|Lake Skate Teach]]>><<trauma -6>><<pass 20>><</link>><<ltrauma>>
 			<br>
-			<<link [[Refuse|Lake Skate Refuse]]>><</link>>
+			<<link [[거절한다|Lake Skate Refuse]]>><</link>>
 			<br>
 		<<else>>
-			A <<person>> glides to a halt in front of you. "Fancy a hand?" <<he>> asks. "I could give you some pointers."
+			<<person_i>> 당신의 앞에 미끄러지듯 멈춰선다. "도와줄까?" <<He_ga>> 물었다. "조언 좀 해주면서 봐줄게."
 			<br><br>
 
-			<<link [[Accept (0:20)|Lake Skate Learn]]>><<trauma -6>><<pass 20>><<danceskill 6>><</link>><<gdanceskill>>
+			<<link [[받아들인다 (0:20)|Lake Skate Learn]]>><<trauma -6>><<pass 20>><<danceskill 6>><</link>><<gdanceskill>>
 			<br>
-			<<link [[Refuse|Lake Skate Learn Refuse]]>><</link>>
+			<<link [[거절한다|Lake Skate Learn Refuse]]>><</link>>
 			<br>
 		<</if>>
 	<<else>>
 		<<generatey1>><<person1>><<generatey2>><<generatey3>><<generatey4>>
-		A few delinquents surround a <<person>>. They push <<him>> away from the other teenagers, trying to isolate <<him>>.
+		몇 명의 비행 청소년들이 <<person_ul>> 둘러싸고 있다. 그들은 <<him_ul>> 다른 10대들로부터 밀어내며 <<him_ul>> 고립시킨다.
 		<br><br>
-		<<link [[Intervene (0:05)|Lake Skate Intervene]]>><<def 1>><<famegood 4>><<pass 5>><</link>>
+		<<link [[개입한다 (0:05)|Lake Skate Intervene]]>><<def 1>><<famegood 4>><<pass 5>><</link>>
 		<br>
-		<<link [[Ignore|Lake Shallows Ice]]>><<endevent>><</link>>
+		<<link [[무시한다|Lake Shallows Ice]]>><<endevent>><</link>>
 		<br>
 	<</if>>
 <<else>>
-	<<link [[Next|Lake Shallows Ice]]>><</link>>
+	<<link [[다음|Lake Shallows Ice]]>><</link>>
 	<br>
 <</if>>
 
 :: Lake Skate Intervene
 <<effects>>
 
-You
+당신은
 <<if $danceskill gte 200>>
-	skate
+	스케이트를 타고
 <<else>>
-	wobble
+	비틀거리며
 <</if>>
-over to the <<person>> and delinquents.
+<<person_gwa>> 비행 청소년에게 다가간다.
 
 <<if $submissive gte 1150>>
-	"L-leave <<him>> alone," you say.
+	"멈- 멈춰, <<him_ul>> 괴롭히지마." 당신이 말한다.
 <<elseif $submissive lte 850>>
-	"Oi fuckers," you say. "Leave <<him>> alone."
+	"미친 양아치들아." 당신이 말한다. "<<him_ul>> 가만히 냅둬."
 <<else>>
-	"Leave <<him>> alone," you say.
+	"<<him_ul>> 괴롭히지마." 당신이 말한다.
 <</if>>
 <br><br>
 
 <<person2>>
-The delinquents abandon their quarry, and skate in your direction. "Sounds like someone wants a beating," a <<person>> says, leading the way.
+그들이 괴롭히던 아이를 두고 당신에게 다가온다. "쳐맞고 싶은 새끼가 있나보네?" 한 <<person_i>> 앞장서서 말한다.
 <br><br>
 
 <<if $rng gte 71>>
-	Before you can respond, one of the other delinquents, a <<person3>><<person>>, tumbles to the ice. The <<person1>><<person>> lies behind <<person3>><<him>>, arms around the <<persons>> legs.
+	당신이 반응하기도 전에 무리 중에 <<person3>><<person_i>> 얼음 위로 굴러떨어진다. <<person1>><<person_i>> <<person3>><<him_yi>> 뒤에 누워서, <<persons_yi>> 다리를 붙잡고 있다.
 	<br><br>
 
-	The other two delinquents almost slip as they spin, shocked by the <<person1>><<persons>> daring.
+	다른 두 명의 비행 청소년들도 <<person1>><<persons_yi>> 예상치 못한 행동에 당황해 돌다가 미끄러질 뻔 한다.
 	<br><br>
 
-	<<link [[Charge|Lake Skate Charge]]>><</link>><<dancedifficulty 1 600>>
+	<<link [[달려든다|Lake Skate Charge]]>><</link>><<dancedifficulty 1 600>>
 	<br>
-	<<link [[Mock|Lake Skate Mock]]>><</link>><<englishdifficulty 1 1000>>
+	<<link [[놀린다|Lake Skate Mock]]>><</link>><<englishdifficulty 1 1000>>
 	<br>
 <<else>>
-	<<link [[Charge|Lake Skate Charge 2]]>><</link>><<dancedifficulty 1 1000>>
+	<<link [[달려든다|Lake Skate Charge 2]]>><</link>><<dancedifficulty 1 1000>>
 	<br>
-	<<link [[Brace|Lake Skate Brace]]>><</link>><<physiquedifficulty 1 $physiquemax>>
+	<<link [[버틴다|Lake Skate Brace]]>><</link>><<physiquedifficulty 1 $physiquemax>>
 	<br>
 <</if>>
 
 :: Lake Skate Charge
 <<effects>>
 
-You skate toward the distracted delinquents, and collide with the <<person2>><<person>>.
+당신은 흐트러진 비행 청소년에게 스케이트를 타고 가다가 <<person2>><<person_gwa>> 부딪힌다.
 
 <<if $danceSuccess>>
-	<span class="green">You manage to remain upright</span> as <<he>> tumbles to the ground, grabbing <<his>> friend's arm and bringing <<person4>><<him>> down as well.
+	<span class="green">당신은 그럭저럭 똑바로 중심을 잡았다.</span> <<He_ga>> 땅에 구르면서 <<his_yi>> 친구의 팔을 잡고 <<person4>><<himPost "도">> 넘어뜨린다.
 	<br><br>
 
-	You help the <<person1>><<person>> to <<his>> feet, and skate back to shore before the delinquents can recover.
+	당신은 <<person1>><<person_i>> <<his_yi>> 발을 딛고 일어날 수 있게 돕는다. 그리고 비행 청소년들이 회복하기 전에 호숫가로 돌아간다.
 	<br><br>
 <<else>>
-	<<He>> grasps <<his>> friend's arm, and yours, as <<he>> falls, <span class="red">dragging you with <<him>>.</span><<gstress>><<gpain>><<stress 6>><<pain 4>>
+	<<He_ga>> <<his_yi>> 친구의 팔과 당신의 팔을 잡았다. <<He_ga>> 넘어졌고, <span class="red">당신은 <<himPost "에게">> 끌려간다.</span><<gstress>><<gpain>><<stress 6>><<pain 4>>
 	<br><br>
 
-	A pair of hands grasps your wrists. It's the <<person1>><<person>>. <<He>> helps you to your feet, and together you skate back to shore before the delinquents can recover.
+	<<person1>><<persons_yi>> 양손이 당신의 손을 붙잡는다. <<He_nun>> 당신이 발을 딛고 일어날 수 있게 돕는다. 그리고 함께 비행 청소년들이 회복하기 전에 호숫가로 돌아간다.
 	<br><br>
 <</if>>
 
-"I don't know what they were gonna do to me," <<he>> says. "I don't want to think about it. It doesn't matter. You saved me. Th-thank you."<<ltrauma>><<trauma -6>>
+"쟤들이 나한테 무슨 짓을 할지는 모르겠지만.." <<He_ga>> 말한다. "그만 생각할래. 네가 날 구해준게 중요하지. 고, 고마워."<<ltrauma>><<trauma -6>>
 <br><br>
 
-<<link [[Next|Lake Shallows Ice]]>><<endevent>><</link>>
+<<link [[다음|Lake Shallows Ice]]>><<endevent>><</link>>
 <br>
 
 
@@ -177,41 +177,41 @@ You skate toward the distracted delinquents, and collide with the <<person2>><<p
 
 <<if $englishSuccess>>
 	<<if $submissive gte 1150>>
-		"B-be careful," you say. "Ice can be slippery."
+		"조, 조심해." 당신이 말한다. "빙판이 미끄러워."
 	<<elseif $submissive lte 850>>
-		"Keep sliding like that," you say. "I mean it. It's hilarious."
+		"또 미끄러져봐." 당신이 말한다. "진심이야, 너네 꼴이 진짜 웃겨."
 	<<else>>
-		"You need to be more careful," you say. "Ice can be slippery."
+		"더 조심할 필요가 있네." 당신이 말한다. "얼음이 꽤 미끄럽거든."
 	<</if>>
 	<br><br>
 
-	The <<person2>><<person>> swivels to face you, <span class="green">and loses <<his>> footing.</span> <<He>> slides to the ground, dragging <<his>> remaining friend with <<him>>.
+	<<person2>><<person_i>> 휙 돌아 당신을 향한다. <span class="green">그러다 <<his_yi>> 발이 꼬인다.</span> <<He_ga>> <<his_yi>> 남은 친구들까지 끌고 땅으로 <<him_gwa>> 미끄러진다.
 	<br><br>
 
-	You help the <<person1>><<person>> to <<his>> feet, and skate back to shore before the delinquents can recover.
+	당신은 <<person1>><<person_i>> <<his_yi>> 발을 딛고 일어날 수 있게 돕는다. 그리고 비행 청소년들이 회복하기 전에 호숫가로 돌아간다.
 	<br><br>
 <<else>>
 	<<if $submissive gte 1150>>
-		"S-silly pooheads," you say.
+		"바, 바보 같은 자식들." 당신이 말한다.
 	<<elseif $submissive lte 850>>
-		"Fucking fuckheads," you say.
+		"거지같은 새끼들." 당신이 말한다.
 	<<else>>
-		"Stupid bullies," you say.
+		"멍청한 양아치들." 당신이 말한다.
 	<</if>>
-	<span class="red">It sounded more clever in your head.</span>
+	<span class="red">당신의 머릿 속에선 더 괜찮게 들렸었다.</span>
 	<br><br>
 
-	The <<person2>><<person>> wobbles to a halt in front of you. <<He>> tries to throw a punch, but loses balance. <<He>> grasps <<his>> friend's arm, and yours, and together you tumble to the ice.<<gpain>><<gstress>><<pain 4>><<stress 6>>
+	<<person2>><<person_i>> 비틀거리며 당신의 앞에 멈춰선다. <<He_nun>> 당신을 때리려고 하지만 금방 중심을 잃고 휘청거린다. <<He_ga>> <<his_yi>> 친구의 팔과 당신의 팔을 붙잡아서 다 같이 얼음위로 구른다.<<gpain>><<gstress>><<pain 4>><<stress 6>>
 	<br><br>
 
-	A pair of hands grasps your wrists. It's the <<person1>><<person>>. <<He>> helps you to your feet, and together you skate back to shore before the delinquents can recover.
+	<<person1>><<persons_yi>> 양손이 당신의 손을 붙잡는다. <<He_nun>> 당신이 발을 딛고 일어날 수 있게 돕는다. 그리고 함께 비행 청소년들이 회복하기 전에 호숫가로 돌아간다.
 	<br><br>
 <</if>>
 
-"I don't know what they were gonna do to me," <<he>> says. "I don't want to think about it. It doesn't matter. You saved me. Th-thank you."<<ltrauma>><<trauma -6>>
+"쟤들이 나한테 무슨 짓을 할지는 모르겠지만.." <<He_ga>> 말한다. "그만 생각할래. 네가 날 구해준게 중요하지. 고, 고마워."<<ltrauma>><<trauma -6>>
 <br><br>
 
-<<link [[Next|Lake Shallows Ice]]>><<endevent>><</link>>
+<<link [[다음|Lake Shallows Ice]]>><<endevent>><</link>>
 <br>
 
 
@@ -219,50 +219,50 @@ You skate toward the distracted delinquents, and collide with the <<person2>><<p
 
 
 <<if $danceSuccess>>
-	You skate towards the delinquents as fast as you can. <span class="green">Surprised by your audacity,</span> they throw up their arms in a defensive reflex. You shoulder barge the <<person2>><<person>> into <<his>> friend, sending them both sprawling. The remaining delinquent almost slips in <<person4>><<his>> haste to get away.
+	당신은 최대한 빠른 속도로 놈들을 향해 돌진했다. <span class="green">당신의 대담함에 당황해서</span> 막으려고 반사적으로 팔을 들어올린다. 당신의 어깨가 <<person2>><<person_ul>> 밀치고 <<his_yi>> 친구까지 둘을 나가떨어지게한다. 남은 비행 청소년들은 <<person4>><<his_yi>> 도망에 대부분 부딪혀 넘어진다.
 	<br><br>
 
-	You grasp the <<person1>><<persons>> hand, and together skate back to shore. "I don't know what they were gonna do to me," <<he>> says. "I don't want to think about it. It doesn't matter. You saved me. Th-thank you."<<ltrauma>><<trauma -6>>
+	당신은 <<person1>><<persons_yi>> 손을 잡고 같이 호숫가로 돌아온다. "쟤들이 나한테 무슨 짓을 할지는 모르겠지만.." <<He_ga>> 말한다. "그만 생각할래. 네가 날 구해준게 중요하지. 고, 고마워."<<ltrauma>><<trauma -6>>
 	<br><br>
 
-	<<link [[Next|Lake Shallows Ice]]>><<endevent>><</link>>
+	<<link [[다음|Lake Shallows Ice]]>><<endevent>><</link>>
 	<br>
 <<else>>
-	You skate towards the delinquents as fast you can, <span class="red">but lose balance.</span> You tumble to the ground, skidding to a halt in front of them.<<ggpain>><<gstress>><<pain 8>><<stress 6>>
+	당신은 최대한 빠른 속도로 놈들을 향해 돌진했다. <span class="red">그러나 균형을 잃어버린다.</span> 당신은 바닥에 구르고 미끄러져 그들의 앞에 멈추게 된다.<<ggpain>><<gstress>><<pain 8>><<stress 6>>
 	<br><br>
 
-	The delinquents roar with laughter, so much that they almost slip up themselves. The <<person2>><<person>> grasps your arms, and starts dragging you across the ice.
+	비행 청소년들이 거의 넘어갈듯이 웃어제낀다. <<person2>><<person_i>> 당신의 팔을 붙잡고, 빙판을 가로질러 질질 끌고 간다.
 	<br><br>
 
-	<<link [[Next|Lake Skate Drag]]>><</link>>
+	<<link [[다음|Lake Skate Drag]]>><</link>>
 	<br>
 <</if>>
 
 :: Lake Skate Brace
 <<effects>>
 
-You brace for impact. The <<person2>><<person>> hits first,
+당신은 충격에 대비한다. <<person2>><<person_i>> 먼저 때리고,
 
 <<if $physiqueSuccess>>
-	barging into you. <span class="green">You manage to keep your footing.</span> A <<person3>><<person>> comes next. You grasp <<his>> arm as <<his>> body connects with yours. You spin around, redirecting <<his>> momentum and sending <<him>> back the way <<he>> came. Right at a <<person4>><<person>>.
+	당신에게 덤벼든다. <span class="green">당신은 그럭저럭 똑바로 중심을 잡았다.</span> <<person3>><<person_i>> 이어서 다가온다. <<his_yi>> 몸이 당신에게 닿는 순간 <<his_yi>> 팔을 잡는다. 당신은 돌면서, <<his_yi>> 추진력을 되돌려서 <<person4>><<person_i>>있는 <<him_ga>> 왔던 길로 <<he_rul>> 돌려보낸다.
 	<br><br>
 
-	They collide, and tumble to the ice. The <<person2>><<person>> laughs at <<his>> friends' misfortune, but doesn't seem keen to approach you again.
+	그들은 충돌하고, 얼음으로 굴러떨어진다. <<person2>><<person_i>> <<his_yi>> 친구들을 보고 비웃지만, 당신에게 다시 접근하려하지 않는다.
 	<br><br>
 
-	You grasp the <<person1>><<persons>> hand, and together skate back to shore. "I don't know what they were gonna do to me," <<he>> says. "I don't want to think about it. It doesn't matter. You saved me. Th-thank you."<<ltrauma>><<trauma -6>>
+	당신은 <<person1>><<persons_yi>> 손을 잡고 같이 호숫가로 돌아온다. "쟤들이 나한테 무슨 짓을 할지는 모르겠지만.." <<He_ga>> 말한다. "그만 생각할래. 네가 날 구해준게 중요하지. 고, 고마워."<<ltrauma>><<trauma -6>>
 	<br><br>
 
-	<<link [[Next|Lake Shallows Ice]]>><<endevent>><</link>>
+	<<link [[다음|Lake Shallows Ice]]>><<endevent>><</link>>
 	<br>
 <<else>>
-	barging into you. <span class="red">The force sends you skidding to the ground.</span><<ggpain>><<gstress>><<pain 8>><<stress 6>>
+	당신에게 덤벼든다. <span class="red">그의 힘이 당신을 땅으로 미끄러지게 한다.</span><<ggpain>><<gstress>><<pain 8>><<stress 6>>
 	<br><br>
 
-	The delinquents roar with laughter, so much that they almost slip up themselves. The <<person2>><<person>> grasps your arms, and starts dragging you across the ice.
+	비행 청소년들이 거의 넘어갈듯이 웃어제낀다. <<person2>><<person_i>> 당신의 팔을 붙잡고, 빙판을 가로질러 질질 끌고 간다.
 	<br><br>
 
-	<<link [[Next|Lake Skate Drag]]>><</link>>
+	<<link [[다음|Lake Skate Drag]]>><</link>>
 	<br>
 <</if>>
 
@@ -270,65 +270,65 @@ You brace for impact. The <<person2>><<person>> hits first,
 <<effects>>
 
 <<set $rescued += 1>>
-The delinquents drag you further from shore, debating what to do with you and threatening to kick you with their ice skates if you don't play along.<<gtrauma>><<trauma 6>>
+비행 청소년들이 당신을 호숫가에서 더 멀리 끌어다 놓고, 당신을 어떻게 해야 할지 고민한다. 당신에게 제대로 따라오지 않으면 스케이트로 당신을 차버리겠다고 위협한다.<<gtrauma>><<trauma 6>>
 <br><br>
 
 <<if $syndromeeden gte 1 and $rng gte 75>>
-	You hear a gunshot, distant, but clear across the open lake. You hear the bullet whistle through the air before <span class="red">thudding into the nearby ice.</span>
+	당신은 탁 트인 호수를 가로질러 멀리 들려오는 총성을 듣는다. 당신은 총알이 공기를 가르고 <span class="red">주변 얼음에 박힌 것을 느낀다.</span>
 	<br><br>
-	The trio stop in their tracks. "Was that a gun?" the <<person3>><<person>> asks.
+	3인조가 제자리에 멈춰선다. "방금 그거 총이야...?" <<person3>><<person_i>> 묻는다.
 	<br><br>
-	A second gunshot answers. <span class="red">The bullet lands closer.</span> The ice explodes this time, throwing shards into the air.
+	두 번째 총성이 그 질문에 대답한다. <span class="red">총알이 더 가까운 곳에 박힌다.</span> 빙판에 총알이 박히며 파편이 공중에 마구잡이로 튄다.
 	<br><br>
-	"F-fuck this," the <<person4>><<person>> whimpers. <<He>> turns and skates the way <<he>> came. The others follow close behind.
+	"씨-씨발, 지랄마." <<person4>><<person_i>> 더듬거렸다. <<He_nun>> <<He_ga>> 왔던 곳으로 스케이트를 타고 도망갔다. 다른 둘도 바짝 뒤를 따른다.
 	<br><br>
-	<<tearful>> you rise to your feet. You peer in the direction the bullets came, but can't see your rescuer. They could be lurking anywhere along that tree line.
+	<<tearful>> 당신은 천천히 일어선다. 당신은 총알이 날아온 방향을 바라보지만 도와준 사람은 보이지 않는다. 나무 주변에 숨어있을 지도 모른다.
 	<br><br>
 
 	<<endevent>>
 
-	<<link [[Next|Lake Depths Ice]]>><</link>>
+	<<link [[다음|Lake Depths Ice]]>><</link>>
 	<br>
 	<!-- Modified for Monster People -->
 <<elseif $syndromewolves gte 1 and $rng gte 50 and $wolfpacktrust gte 24>>
 	<<person3>>
-	"What's that?" the <<person>> says, pointing at a dark shape across the ice.
+	"저게 뭐지?" <<person_i>> 빙판 너머의 검은 형체를 가리키며 말한다. 
 	<br><br>
-	The <<person2>><<person>> peers at it. "It's getting closer," <<he>> says, voice betraying worry.
+	<<person2>><<person_i>> 그것을 쳐다본다. "가까워지는 것 같은데." <<He_ga>> 걱정스러운 목소리로 말한다.
 	<br><br>
-	The third delinquent, a <<person4>><<person>> takes a step backwards. <span class="red">"It-it's a wolf,"</span> <<he>> stutters. The trio stand motionless for a moment, then, slipping more than once, turn and skate away. You're left alone on the ice.
+	<<person4>><<person_i>> 뒤로 한 걸음 물러난다. <span class="red">"늑, 늑대 잖아...!"</span> <<He_ga>> 말을 더듬었다. 3인조는 잠시 굳어있더니, 곧 넘어지거나 미끄러지며 스케이트를 타고 달아난다. 당신은 얼음 위에 홀로 남겨졌다.
 	<br><br>
 	<<endevent>><<npc "Black Wolf">>
-	You hear rapid footsteps, then a warm tongue licks your face. It's the Black Wolf.<<lstress>><<stress -6>>
+	당신이 재빠른 발소리를 듣자마자, 뺨에 따스한 혀의 감촉이 닿는다. 검은 늑대다.<<lstress>><<stress -6>>
 	<br><br>
 	<<if $monster is 1>>
-		"Humans. So crude. You belong with wolf." <<bHe>> watches the delinquents run, before turning and walking away. <<bHe>> looks at you over <<bhis>> shoulder.
+		"인간들, 너무 잔인하다. 너는 늑대가 어울려." <<bHe_nun>> 놈들이 도망치는 것을 지켜보다 돌아서서 가버린다. <<bHe_ga>> <<bhis_yi>> 어깨너머로 당신을 쳐다본다.
 	<<else>>
-		<<bHe>> seems uninterested in pursuing the delinquents, instead walking back the way it came. It stops and looks over its shoulder.
+		<<bHe_nun>> 놈들을 쫓는 것에는 관심이 없어보이고, 그 대신 왔던 길을 돌아간다. 그러다 멈춰서서 당신을 쳐다본다.
 	<</if>>
 	<br><br>
 
 	<<endevent>>
 
-	<<link [[Go to the wolf cave (0:30)|Wolf Cave Clearing]]>><<pass 30>><</link>>
+	<<link [[늑대 동굴로 간다 (0:30)|Wolf Cave Clearing]]>><<pass 30>><</link>>
 	<br>
-	<<link [[Stay at the lake|Lake Depths Ice]]>><</link>>
+	<<link [[호수에 남는다|Lake Depths Ice]]>><</link>>
 	<br>
 <<else>>
 
-	<span class="green">They're interrupted by a shout.</span> It's the <<person1>><<person>>, following across the ice. <<Hes>> not alone.
+	<span class="green">고함 소리가 그들을 방해한다.</span> <<person1>><<person_i>> 빙판을 가로질러 뛰어온다. <<He_nun>> 혼자가 아니다.
 	<br><br>
 
-	The delinquents hurl insults at the pursuers, but they're outnumbered. They skate away, leaving you lying on the ice.
+	비행 청소년들이 추격자들에게 욕설을 퍼붓지만 수적으로 열세다. 그들은 당신을 얼음 위에 둔채 도망간다.
 	<br><br>
 
 	<<generatey5>>
-	<<tearful>> you rise to your feet. The <<person1>><<person>> and <<his>> friends arrive at your side. They're all a bit older than <<him>>. It's a <<person5>><<person>> who speaks.
+	<<tearful>> 당신은 천천히 일어선다. <<person1>><<person_gwa>> <<his_yi>> 친구들이 당신의 곁으로 다가온다. 그들은 모두 <<himPost "보다">> 조금 나이가 많아보인다. <<person5>><<person_i>> 입을 연다.
 	<br><br>
-	"Heard you saved my lil <<person1>><<if $pronoun is "m">>bro<<else>>sis<</if>>," <<person5>><<he>> says. "Good of you. Excuse me though." <<He>> pushes <<himself>> after the delinquents, and the other friends follow. The <<person1>><<person>> stays behind, and gives you a shy smile. Together, you return to shore.<<gcool>><<status 1>>
+	"네가 내 <<person1>><<if $pronoun is "m">>남동생<<else>>여동생<</if>>을 구해줬다며?" <<person5>><<He_ga>> 말한다. "정말로 고마워, 이만 실례할게." <<He_ga>> <<himself>> 도망친 애들을 쫓아가고 다른 친구들이 따라간다. <<person1>><<person_i>> 그 뒤에 서있다가 멋쩍은 미소를 지어보인다. 당신은 함께 호숫가로 돌아온다.<<gcool>><<status 1>>
 	<br><br>
 
-	<<link [[Next|Lake Shallows Ice]]>><<endevent>><</link>>
+	<<link [[다음|Lake Shallows Ice]]>><<endevent>><</link>>
 	<br>
 <</if>>
 
@@ -339,20 +339,20 @@ The delinquents drag you further from shore, debating what to do with you and th
 :: Lake Skate Teach
 <<effects>>
 
-There's no substitute for practise, but your presence is great for the <<persons>> confidence. You give <<him>> pointers, and offer an arm when <<he>> needs it. <<He>> doesn't seem quite so wobbly by the end.
+연습을 이길 수 있는 건 없지만, <<persons_yi>> 자신감에 도움이 될 방법은 있다. 당신은 <<himPost "에게">> 충고를 해주며 <<He_ga>> 도움이 필요할 때마다 잡아줬다. <<He_nun>> 마지막에는 제법 흔들리지 않고 탈 수 있게 됐다.
 <br><br>
 
-<<link [[Next|Lake Shallows Ice]]>><<endevent>><</link>>
+<<link [[다음|Lake Shallows Ice]]>><<endevent>><</link>>
 <br>
 
 
 :: Lake Skate Refuse
 <<effects>>
 
-"Thanks anyway," the <<person>> says, disappointed. <<He>> wobbles away.
+"음, 그래. 좋은 시간 보내.." <<person_i>> 풀죽은 채로 말한다. <<He_nun>> 휘청거리며 멀어졌다.
 <br><br>
 
-<<link [[Next|Lake Shallows Ice]]>><<endevent>><</link>>
+<<link [[다음|Lake Shallows Ice]]>><<endevent>><</link>>
 <br>
 
 
@@ -362,49 +362,49 @@ There's no substitute for practise, but your presence is great for the <<persons
 
 
 <<if $danceskill gte 800>>
-	You perform some tricks in front of the <<person>>. <<He>> watches, then points out the flaws in your technique.
+	당신은 <<persons_yi>> 앞에서 묘기를 부린다. <<He_nun>> 그것을 지켜보다가, 이따금씩 당신의 묘기가 더 나아질 방법대해서 충고한다.
 <<elseif $danceskill gte 400>>
-	You skate in front of the <<person>>. <<He>> watches, then offers tips on how to improve your speed and balance.
+	당신은 <<persons_yi>> 앞에서 스케이트를 탄다. <<He_nun>> 그것을 지켜보다가, 당신에게 속도와 균형에 대해 조언을 한다.
 <<elseif $danceskill gte 100>>
-	The skate in front of the <<person>>. <<He>> watches, then offers tips on how to improve your balance.
+	당신은 <<persons_yi>> 앞에서 스케이트를 탄다. <<He_nun>> 그것을 지켜보다가, 당신에게 균형을 잘 잡는 방법에 대해 조언을 한다.
 <<else>>
-	The <<person>> holds your arm as you skate, and gives you pointers. You're able to skate more adventurously than normal, knowing you aren't going to end up on your ass.
+	<<persons_yi>> 당신의 손을 잡고 스케이트를 타는 것을 도우며 조언을 한다. 당신은 그가 잡아주고 있어서 더욱 모험적으로 스케이트를 탈 수 있었다.
 <</if>>
-You learn a lot.
+당신은 많은 것을 배웠다.
 <br><br>
 
 
-<<link [[Next|Lake Shallows Ice]]>><<endevent>><</link>>
+<<link [[다음|Lake Shallows Ice]]>><<endevent>><</link>>
 <br>
 
 
 :: Lake Skate Learn Refuse
 <<effects>>
 
-The <<person>> shrugs. "Suit yourself," <<he>> says. "Good luck." <<He>> skates away.
+<<person_un>> 어깨를 으쓱한다. "마음대로 해." <<he_ga>> 말한다. "행운을 빌어." <<He_ga>> 스케이트를 타고 떠나간다.
 <br><br>
 
-<<link [[Next|Lake Shallows Ice]]>><<endevent>><</link>>
+<<link [[다음|Lake Shallows Ice]]>><<endevent>><</link>>
 <br>
 
 
 :: Lake Skate Shove
 <<effects>>
 
-You shove the <<person>> away from you. <<He>> looses <<his>> footing, and lands on <<his>> back. You hear laughter from several directions.
+당신은 <<person_ul>> 당신으로부터 밀어냈다. <<He_nun>> <<his_yi>>발을 헛디뎌 한 발을 어정쩡하게 <<his_yi>> 뒤쪽에 딛는다. 여러 방향에서 웃음소리가 들려온다.
 <br><br>
 
 <<if $rng gte 81>>
-	Incensed, the <<person>> rises to <<his>> feet, and lunges.
+	<<person_un>> 화가 잔뜩 나서 <<his_yi>> 발을 딛고 일어나, 당신에게 돌진한다.
 	<br><br>
 
-	<<link [[Next|Lake Skate Rape]]>><<set $molestationstart to 1>><<set $phase to 1>><</link>>
+	<<link [[다음|Lake Skate Rape]]>><<set $molestationstart to 1>><<set $phase to 1>><</link>>
 	<br>
 <<else>>
-	Pride wounded, the <<person>> rises to <<his>> feet, and skates away.
+	<<person_un>> 자존심에 상처를 입은 채 <<his_yi>> 발을 딛고 일어나, 스케이트를 타고 달아난다.
 	<br><br>
 
-	<<link [[Next|Lake Shallows Ice]]>><</link>>
+	<<link [[다음|Lake Shallows Ice]]>><</link>>
 	<br>
 <</if>>
 
@@ -412,16 +412,16 @@ You shove the <<person>> away from you. <<He>> looses <<his>> footing, and lands
 <<effects>>
 
 <<if $rng gte 61>>
-	The <<person>> gropes and fondles you, then puts <<his>> hand over your mouth.
+	<<person_un>> 당신을 더듬고 애무하며, <<his_yi>> 손으로 입을 막았다.
 	<br><br>
 
-	<<link [[Next|Lake Skate Rape]]>><<set $molestationstart to 1>><<set $phase to 0>><</link>>
+	<<link [[다음|Lake Skate Rape]]>><<set $molestationstart to 1>><<set $phase to 0>><</link>>
 	<br>
 <<else>>
-	The <<person>> gropes and fondles you for a few moments, before skating off to find someone else to harass.
+	<<person_i>> 다른 사람을 괴롭히러 가기 전에 당신을 몇 분정도 더듬고 애무한다. 
 	<br><br>
 
-	<<link [[Next|Lake Shallows Ice]]>><</link>>
+	<<link [[다음|Lake Shallows Ice]]>><</link>>
 	<br>
 <</if>>
 
@@ -455,73 +455,73 @@ You shove the <<person>> away from you. <<He>> looses <<his>> footing, and lands
 <<actionsman>>
 
 <<if $enemyhealth lte 0>>
-	<span id="next"><<link [[Next|Lake Skate Rape Finish]]>><</link>></span><<nexttext>>
+	<span id="next"><<link [[다음|Lake Skate Rape Finish]]>><</link>></span><<nexttext>>
 <<elseif $enemyarousal gte $enemyarousalmax>>
-	<span id="next"><<link [[Next|Lake Skate Rape Finish]]>><</link>></span><<nexttext>>
+	<span id="next"><<link [[다음|Lake Skate Rape Finish]]>><</link>></span><<nexttext>>
 <<elseif $alarm is 1 and $rescue is 1>>
-	<span id="next"><<link [[Next|Lake Skate Rape Finish]]>><</link>></span><<nexttext>>
+	<span id="next"><<link [[다음|Lake Skate Rape Finish]]>><</link>></span><<nexttext>>
 <<else>>
-	<span id="next"><<link [[Next|Lake Skate Rape]]>><</link>></span><<nexttext>>
+	<span id="next"><<link [[다음|Lake Skate Rape]]>><</link>></span><<nexttext>>
 <</if>>
 
 :: Lake Skate Rape Finish
 <<effects>>
 <<if $enemyarousal gte $enemyarousalmax>>
 	<<ejaculation>>
-	<<He>> shoves you forward, and skates off to find someone else to harass.
+	<<He_nun>> 당신을 앞으로 밀치고, 다른 사람을 괴롭히러 간다.
 	<br><br>
-	<<tearful>> you steady yourself.
+	<<tearful>> 당신은 진정하려 애쓴다.
 	<br><br>
 	<<clotheson>>
 	<<endcombat>>
-	<<link [[Next|Lake Shallows Ice]]>><</link>>
+	<<link [[다음|Lake Shallows Ice]]>><</link>>
 	<br>
 
 <<elseif $enemyhealth lte 0>>
-	You shove the <<person>> onto <<his>> ass. <<tearful>> you skate away.
+	당신은 <<person_ul>> 때리고 <<his_yi>> 몸을 밀쳐냈다. <<tearful>> 당신은 스케이트를 타고 떠난다.
 	<br><br>
 	<<clotheson>>
 	<<endcombat>>
-	<<link [[Next|Lake Shallows Ice]]>><</link>>
+	<<link [[다음|Lake Shallows Ice]]>><</link>>
 	<br>
 
 <<else>>
 	<<set $rescued += 1>>
-	The cry attracts attention. The <<person>> looks around, nervous. <<He>> shoves you forward and skates away.
+	당신이 비명을 지르자 주의가 끌린다. <<person_un>> 주변을 돌아보고는 긴장한다. <<He_nun>> 당신을 앞으로 밀치고, 스케이트를 타고 떠난다.
 	<br><br>
-	<<tearful>> you steady yourself.
+	<<tearful>> 당신은 진정하려 애쓴다.
 	<br><br>
 	<<clotheson>>
 	<<endcombat>>
-	<<link [[Next|Lake Shallows Ice]]>><</link>>
+	<<link [[다음|Lake Shallows Ice]]>><</link>>
 	<br>
 
 <</if>>
 
 :: Lake Skate Challenge
 <<effects>>
-You race after the <<person>>. <<He>> speeds up when <<he>> notices you following.
+당신은 <<person_ul>> 쫓아 경주한다. <<He_nun>> 당신이 <<he_rul>> 쫓는 것을 느끼자 속도를 높였다.
 <<if $danceSuccess>>
 
 	<<if $danceskill gte 600>>
-		You're able to keep up, <span class="green">and then overtake <<him>>.</span> You spin and wink.
+		당신은 서서히 따라잡고, <span class="green"><<him_ul>> 앞서 나간다.</span> 당신은 빙글 돌고서 윙크한다.
 	<<else>>
-		Driven by the desire to win, you manage to keep up, <span class="green">and even overtake <<him>></span> You spin and wink.
+		당신은 승부욕으로 가득차 겨우 따라잡았고, <span class="green"><<him_ul>> 앞서 나간다.</span> 당신은 빙글 돌고서 윙크한다.
 	<</if>>
 	<<gcool>><<status 1>>
 	<br><br>
 
-	<<link [[Next|Lake Shallows Ice]]>><<endevent>><</link>>
+	<<link [[다음|Lake Shallows Ice]]>><<endevent>><</link>>
 	<br>
 <<else>>
 	<<if $danceskill gte 800>>
-		<<Hes>> fast, <span class="red">too fast.</span> Realising you won't catch up, you slow to a stop.<<lcool>><<status -10>>
+		<<He_nun>> 빠르게 치고 나간다. <span class="red">그러다 점점 멀어진다.</span> 당신은 따라잡지 못할 거란 걸 깨닫고 천천히 멈춘다.<<lcool>><<status -10>>
 	<<else>>
-		In your rush to catch up, <span class="red">you lose your balance.</span> You're left sprawled on the ice.<<gpain>><<gstress>><<lcool>><<pain 4>><<stress 6>><<status -1>>
+		당신은 따라잡으려고 돌진했고, <span class="red">균형을 잃어버린다.</span> 당신은 빙판 위로 널브러진다.<<gpain>><<gstress>><<lcool>><<pain 4>><<stress 6>><<status -1>>
 	<</if>>
 	<br><br>
 
-	<<link [[Next|Lake Shallows Ice]]>><<endevent>><</link>>
+	<<link [[다음|Lake Shallows Ice]]>><<endevent>><</link>>
 	<br>
 <</if>>
 
@@ -533,39 +533,39 @@ You race after the <<person>>. <<He>> speeds up when <<he>> notices you followin
 
 
 <<if $danceskill gte 200>>
-	You skate over.
+	당신은 스케이트를 탄다.
 <<else>>
-	You manage to wobble your way over.
+	당신은 비틀거리면서 앞으로 나아간다.
 <</if>>
-<<Hes>> blushing.
+<<He_ga>> 얼굴을 붉힌다.
 <br><br>
 
 <<if $submissive gte 1150>>
-	"I-it's okay to be shy," you say. "But I saw you watching me."
+	"부, 부끄러워 할 수도 있지." 당신이 말한다. "하지만 네가 날 보고 있는 걸 봤어."
 <<elseif $submissive lte 850>>
-	"I saw you watching me," you say. "No need to be shy."
+	"날 보고 있는 걸 봤어." 당신이 말한다. "부끄러워할 필요 없어."
 <<else>>
-	"There's no need to be shy," you say.
+	"그렇게 부끄러워할 필요 없어." 당신이 말한다.
 <</if>>
-<<Hes>> already wearing ice skates. You hold out your hand.
+<<He_nun>> 스케이트를 거의 다 신었다. 당신은 손을 내민다.
 <<promiscuity1>>
 
 <<if $danceskill gte 200>>
-	You help <<him>> across the ice. You have to steady <<him>> more than once when <<he>> slips. <<He>> laughs, embarrassed, but <<his>> nervousness abates.
+	당신은 <<him_i>> 빙판 위를 지나갈 수 있게 돕는다. 당신은 <<he_ga>> 휘청일 때마다 <<him_ul>> 잡고 버텨준다. <<He_nun>> 부끄러워 하며 웃지만, 처음보다 <<his_yi>> 긴장이 풀린 것을 느낀다.
 	<br><br>
 <<else>>
-	You're not much more experienced than <<him>>, and inevitably end up sprawled together on the ice. <<He>> laughs, <<his>> nervousness abated.
+	당신은 <<himPost "보다">> 그렇게 경험이 많지 않아서, 결국 함께 얼음 위로 널브러진다. <<He_ga>> 소리내어 웃는다, 처음보다 <<his_yi>> 긴장이 풀린 것을 느낀다.
 	<br><br>
 <</if>>
 
-You're a fair way onto the ice, well away from the other teenagers.
+당신은 평평한 빙판 위에 있다. 다른 10대들은 멀리 떨어져있다.
 <br><br>
 
 <<if $promiscuity gte 15>>
-	<<link [[Seduce|Lake Skate Seduce]]>><</link>><<promiscuous2>>
+	<<link [[유혹한다|Lake Skate Seduce]]>><</link>><<promiscuous2>>
 	<br>
 <</if>>
-<<link [[Help them back to shore|Lake Skate Shore]]>><</link>>
+<<link [[호숫가로 돌아가는 것을 도와준다|Lake Skate Shore]]>><</link>>
 <br>
 
 
@@ -578,39 +578,39 @@ You're a fair way onto the ice, well away from the other teenagers.
 <<seductioncheck>>
 <br><br>
 <<if $seductionskill lt 1000>>
-	<span class="gold">You feel more confident in your powers of seduction.</span>
+	<span class="gold">당신은 유혹에 있어서 더 자신감을 느낀다.</span>
 	<br><br>
 <</if>>
 <<seductionskilluse>>
 
 <<if $danceskill gte 200>>
-	You press your body against the <<persons>>, and breathe on <<his>> neck.
+	당신은 당신의 몸을 <<persons_yi>> 몸에 가까이 붙이고 <<his_yi>> 목에 얼굴을 묻는다.
 <<else>>
-	You roll on top of the <<person>>, and breathe on <<his>> neck.
+	당신은 <<person_yi>> 위에 구르고 <<his_yi>> 목에 얼굴을 묻는다.
 <</if>>
 <<promiscuity2>>
 
 <<if $seductionrating gte $seductionrequired>>
 
-	<<He>> shivers, <span class="green">and pulls you closer.</span>
+	<<He_nun>> 잘게 떨더니, <span class="green">당신을 가까이 끌어당긴다.</span>
 	<br><br>
 
 
-	<<link [[Next|Lake Skate Sex]]>><<set $sexstart to 1>><</link>>
+	<<link [[다음|Lake Skate Sex]]>><<set $sexstart to 1>><</link>>
 	<br>
 <<else>>
-	<<He>> shivers, <span class="red">but <<his>> nervousness returns,</span> and <<he>> looks away.
+	<<He_nun>> 잘게 떨었지만, <span class="red"><<his_yi>> 소심함이 충동을 억누른다.</span> <<He_nun>> 시선을 돌린다.
 	<br><br>
 
 	<<if $danceskill gte 200>>
-		You help <<him>> back to shore.
+		당신은 <<him_ul>> 호숫가에 데려다준다.
 	<<else>>
-		You help <<him>> to <<his>> feet, and back to shore.
+		당신은 <<his_yi>> 발을 딛고 일어서게 도와준 후, <<him_ul>> 호숫가에 데려다준다.
 	<</if>>
-	<<He>> looks like <<he>> wants to say something, but can't find the words.
+	<<He_nun>> <<he_ga>> 원하는 것을 말하고 싶어 보였지만, 아무말도 하지 않았다.
 	<br><br>
 
-	<<link [[Next|Lake Shallows Ice]]>><</link>>
+	<<link [[다음|Lake Shallows Ice]]>><</link>>
 	<br>
 
 <</if>>
@@ -633,13 +633,13 @@ You're a fair way onto the ice, well away from the other teenagers.
 <br><br>
 <<actionsman>>
 <<if $finish is 1>>
-	<span id="next"><<link [[Next|Lake Skate Sex Finish]]>><</link>></span><<nexttext>>
+	<span id="next"><<link [[다음|Lake Skate Sex Finish]]>><</link>></span><<nexttext>>
 <<elseif $enemyhealth lte 0>>
-	<span id="next"><<link [[Next|Lake Skate Sex Finish]]>><</link>></span><<nexttext>>
+	<span id="next"><<link [[다음|Lake Skate Sex Finish]]>><</link>></span><<nexttext>>
 <<elseif $enemyarousal gte $enemyarousalmax>>
-	<span id="next"><<link [[Next|Lake Skate Sex Finish]]>><</link>></span><<nexttext>>
+	<span id="next"><<link [[다음|Lake Skate Sex Finish]]>><</link>></span><<nexttext>>
 <<else>>
-	<span id="next"><<link [[Next|Lake Skate Sex]]>><</link>></span><<nexttext>>
+	<span id="next"><<link [[다음|Lake Skate Sex]]>><</link>></span><<nexttext>>
 <</if>>
 
 :: Lake Skate Sex Finish
@@ -647,30 +647,30 @@ You're a fair way onto the ice, well away from the other teenagers.
 <<set $outside to 0>><<effects>>
 <<if $enemyarousal gte $enemyarousalmax>>
 	<<ejaculation>>
-	<<He>> pants against the ice.
+	<<He_ga>> 옷을 챙겨입는다.
 	<br><br>
 	<<clotheson>>
-	<<tearful>> you help <<him>> to shore. <<He>> gives you a parting kiss on the cheek.
+	<<tearful>> 당신은 <<him_ul>> 호숫가에 데려다준다. <<He_ga>> 볼에 작별의 입맞춤을 한다.
 	<br><br>
 	<<endcombat>>
-	<<link [[Next|Lake Shallows Ice]]>><</link>>
+	<<link [[다음|Lake Shallows Ice]]>><</link>>
 <<elseif $enemyhealth lte 0>>
-	You pull away from the <<person>>. <<He>> tries to follow, but slips on the ice.
+	당신은 <<person_ul>> 밀쳐낸다. <<He_nun>> 따라오려했으나, 얼음 위에서 미끄러졌다.
 	<br><br>
-	<<tearful>> you make it some distance away.
+	<<tearful>> 당신은 그 자리에서 멀어진다.
 	<br><br>
 	<<clotheson>>
 	<<endcombat>>
-	<<link [[Next|Lake Shallows Ice]]>><</link>>
+	<<link [[다음|Lake Shallows Ice]]>><</link>>
 <<else>>
 	<<clotheson>>
-	You help the <<person>> back to shore. <<He>> looks like <<he>> wants to say something, but can't find the words.
+	당신은 <<person_ul>> 호숫가에 데려다준다. <<He_nun>> <<he_ga>> 원하는 것을 말하고 싶어 보였지만, 아무말도 하지 않았다.
 	<br><br>
-	<<tearful>> you skate back onto the ice.
+	<<tearful>> 당신은 다시 빙판 위로 올라왔다.
 	<br><br>
 
 	<<endcombat>>
-	<<link [[Next|Lake Shallows Ice]]>><</link>>
+	<<link [[다음|Lake Shallows Ice]]>><</link>>
 <</if>>
 
 
@@ -678,12 +678,12 @@ You're a fair way onto the ice, well away from the other teenagers.
 <<effects>>
 
 <<if $danceskill gte 200>>
-	You help the <<person>> back to shore. <<He>> kisses your cheek before you part.<<ltrauma>><<trauma -6>>
+	당신은 <<person_ul>> 호숫가에 데려다준다. <<he_ga>> 헤어지기 전에 뺨에 입맞춤을 한다.<<ltrauma>><<trauma -6>>
 	<br><br>
 <<else>>
-	You help each other to your feet, and return to the shore. The <<person>> is still giggling. <<He>> kisses your cheek before you part.<<ltrauma>><<trauma -6>>
+	당신은 서로 도와서 호숫가에 도착한다. <<person_i>> 여전히 킥킥 웃는다. <<he_ga>> 헤어지기 전에 뺨에 입맞춤을 한다.<<ltrauma>><<trauma -6>>
 	<br><br>
 <</if>>
 
-<<link [[Next|Lake Shallows Ice]]>><<endevent>><</link>>
+<<link [[다음|Lake Shallows Ice]]>><<endevent>><</link>>
 <br>

--- a/game/overworld-forest/loc-lake/widgets.twee
+++ b/game/overworld-forest/loc-lake/widgets.twee
@@ -33,25 +33,25 @@
 <<widget "destinationlake">>
 
 <<if $bus is "lakeshallows">>
-<<link [[Next|Lake Shallows]]>><</link>>
+<<link [[다음|Lake Shallows]]>><</link>>
 <br>
 <<elseif $bus is "lakedepths">>
-<<link [[Next|Lake Depths]]>><</link>>
+<<link [[다음|Lake Depths]]>><</link>>
 <br>
 <<elseif $bus is "lakefirepit">>
-<<link [[Next|Lake Firepit]]>><</link>>
+<<link [[다음|Lake Firepit]]>><</link>>
 <br>
 <<elseif $bus is "lakefishingrock">>
-<<link [[Next|Lake Fishing Rock]]>><</link>>
+<<link [[다음|Lake Fishing Rock]]>><</link>>
 <br>
 <<elseif $bus is "lakecampsite">>
-<<link [[Next|Lake Campsite]]>><</link>>
+<<link [[다음|Lake Campsite]]>><</link>>
 <br>
 <<elseif $bus is "lakewaterfall">>
-<<link [[Next|Lake Waterfall]]>><</link>>
+<<link [[다음|Lake Waterfall]]>><</link>>
 <br>
 <<else>>
-<<link [[Next|Lake Shore]]>><</link>>
+<<link [[다음|Lake Shore]]>><</link>>
 <br>
 <</if>>
 
@@ -59,20 +59,20 @@
 
 <<widget "passoutlake">>
 
-You've pushed yourself too much.
+당신은 몸을 너무 혹사시켰다.
 <br><br>
 <<passout>>
 
 <<set $danger to random(1, 10000)>>
 
 <<if ($loveInterest.primary is "Eden" or $loveInterest.secondary is "Eden" or $loveInterest.tertiary is "Eden") and random(1,2) is 2>>
-	<<link [[Next|Eden Passout Lake Rescue]]>><</link>>
+	<<link [[다음|Eden Passout Lake Rescue]]>><</link>>
 <<elseif $danger gte (9900 - $allure)>>
 	<<if $laketeenspresent is 1 and $season isnot "winter">>
-		<<link [[Next|Lake Mermaid]]>><</link>>
+		<<link [[다음|Lake Mermaid]]>><</link>>
 		<br>
 	<<else>>
-		<<link [[Next|Lake Ritual]]>><</link>>
+		<<link [[다음|Lake Ritual]]>><</link>>
 		<br>
 	<</if>>
 <<else>>
@@ -88,19 +88,19 @@ You've pushed yourself too much.
 
 <<widget "lakejourney">>
 <<beastNEWinit 1 wolf>>
-Someone screams. Everyone turns and backs away from the newcomer, a <<beasttype>>.
+누군가가 비명을 지른다. 모두가 새로 온 것을 돌아보며 물러난다. <<beasttype_ga>> 나타났다.
 <<if $monster is 1>>
-	<<bHis>> nude body leaves little to the imagination, <<bhis>> genitals on full display to the crowd. <<bHe>> makes no attempt to cover <<bhimself>> up. Some laugh nervously, while others shield their eyes.
+	<<bhis_yi>> 나체는 상상을 초월한다. <<bhis_yi>> 성기가 사람들에게 전부 내보여진다. <<bHe_nun>> <<bhimself>> 가리려는 시도조차 하지 않는다. 어떤 이는 크게 웃고, 어떤 이는 눈을 가린다.
 <</if>>
-<<bHe>> stands some way apart and watches.
+<<bHe_ga>> 멀리 떨어져 서서 지켜본다.
 <br><br>
 <!-- Modified for Monster People -->
 <<if $deviancy gte 15>>
-	<<link [[Deal with it|Lake Wolf Sex]]>><<set $sexstart to 1>><</link>><<deviant2>><<gcool>>
+	<<link [[그것을 달랜다|Lake Wolf Sex]]>><<set $sexstart to 1>><</link>><<deviant2>><<gcool>>
 	<br>
 <</if>>
 
-<<link [[Run away|Lake Wolf Run]]>><<stress 3>><</link>><<gstress>>
+<<link [[도망친다|Lake Wolf Run]]>><<stress 3>><</link>><<gstress>>
 <br>
 
 <</widget>>
@@ -108,11 +108,11 @@ Someone screams. Everyone turns and backs away from the newcomer, a <<beasttype>
 <<widget "lakereturnjourney">>
 
 <<if $laketeenspresent is 1 and $hour is 20>>
-	It's getting late, and the shadows of the forest grow longer. People are preparing to return to town. No one wants to be left to travel alone.
+	시간이 늦어지고, 숲의 그림자는 더 길어진다. 사람들은 마을로 돌아갈 준비를 하고 있다. 아무도 혼자 남겨져 떠돌기를 원하지 않는다.
 	<br><br>
 
 	<<if $exposed lte 0>>
-		<<link [[Go with them (0:30)|Lake Return Journey]]>><<set $foresthunt to 0>><<pass 30>><</link>>
+		<<link [[함께 간다 (0:30)|Lake Return Journey]]>><<set $foresthunt to 0>><<pass 30>><</link>>
 		<br><br>
 	<</if>>
 <</if>>
@@ -131,49 +131,49 @@ Someone screams. Everyone turns and backs away from the newcomer, a <<beasttype>
 
 <<if $bus is "lakeshallows">>
 	<<if $laketeenspresent is 1>>
-		<<generatey1>><<person1>> A <<person>> watches you from the bank.
+		<<generatey1>><<person1>> <<person_i>> 호숫가에서 당신을 쳐다본다.
 		<br><br>
-		<<link [[Wave (0:01)|Lake Wave]]>><<stress -2>><</link>><<lstress>>
+		<<link [[손을 흔든다 (0:01)|Lake Wave]]>><<stress -2>><</link>><<lstress>>
 		<br>
-		<<link [[Ignore|Lake Shallows]]>><<endevent>><<set $eventskip to 1>><</link>>
+		<<link [[무시한다|Lake Shallows]]>><<endevent>><<set $eventskip to 1>><</link>>
 		<br>
 		<<if $player.gender_appearance is "f" and $exhibitionism gte 35>>
-			<<link [[Flash|Lake Flash]]>><</link>><<exhibitionist3>>
+			<<link [[몸을 내보인다|Lake Flash]]>><</link>><<exhibitionist3>>
 			<br>
 		<</if>>
 	<<else>>
-		Your leg gets tangled in some weeds. It takes a few minutes of struggling to free yourself.
+		당신의 다리에 잡초가 엉킨다. 자유로워지려면 몇 분간 버둥거려야 할 것 같다.
 		<<gtiredness>><<tiredness 2>>
 		<br><br>
 		<<pass 3>>
-		<<link [[Next|Lake Shallows]]>><<set $eventskip to 1>><</link>>
+		<<link [[다음|Lake Shallows]]>><<set $eventskip to 1>><</link>>
 		<br>
 	<</if>>
 <<else>>
 	<<if $rng gte 91 and $weather is "rain" and $bestialitydisable is "f" and $voredisable is "f" and $hallucinations gte 2 and $controlled is 0>>
-	Something large surges through the water beneath you. A gaping maw grips your thighs.
+	당신 밑의 물속에서 뭔가 거대한 것이 솟구쳐 올랐다. 쩍 벌어진 구멍 같은 것이 허벅지를 움켜잡는다.
 	<br><br>
 
-	<<link [[Next|Lake Vore]]>><<set $molestationstart to 1>><</link>>
+	<<link [[다음|Lake Vore]]>><<set $molestationstart to 1>><</link>>
 	<br>
 	<<elseif $rng gte 81 and $swarmdisable is "f">>
-	The water is agitated. Swarms of small fish encircle you.
+	물이 불안하게 요동친다. 작은 물고기 떼가 당신을 에워싸고 있다.
 	<br><br>
 
-	<<link [[Next|Lake Depths Swarm]]>><<set $molestationstart to 1>><</link>>
+	<<link [[다음|Lake Depths Swarm]]>><<set $molestationstart to 1>><</link>>
 	<br>
 	<<else>>
 		<<if $daystate is "night" and $weather is "rain">>
-		Something brushes your leg and startles you. You look beneath the dark and violent water, but can't see anything. You feel strange.
+		뭔가가 다리를 스쳐 당신을 놀라게 한다. 당신은 어둡고 격렬한 물 안을 들여다 보지만 아무것도 볼 수 없었다. 기분이 이상하다.
 		<<garousal>><<arousal 600>><<gstress>><<stress 6>>
 		<br><br>
 		<<else>>
-		Something brushes your leg and startles you. You look beneath the water, but can't see anything.
+		뭔가가 다리를 스쳐 당신을 놀라게 한다. 당신은 물 안을 들여다 보지만 아무것도 볼 수 없었다.
 		<<garousal>><<arousal 600>><<gstress>><<stress 6>>
 		<br><br>
 		<</if>>
 
-	<<link [[Next|Lake Depths]]>><<set $eventskip to 1>><</link>>
+	<<link [[다음|Lake Depths]]>><<set $eventskip to 1>><</link>>
 	<br>
 	<</if>>
 <</if>>
@@ -185,84 +185,84 @@ Someone screams. Everyone turns and backs away from the newcomer, a <<beasttype>
 <<if $rng gte 81>>
 	<<dancedifficulty 1 1000 true>>
 	<<if $danceSuccess>>
-		The wind picks up, almost knocking you over, <span class="green">but you manage to keep your footing.</span>
+		바람은 점점 거세지고, 거의 당신을 넘어뜨릴 것 같이 느껴진다. <span class="green">하지만 당신은 그럭저럭 버텨낸다.</span>
 		<br><br>
 	<<else>>
-		The wind picks up, <span class="red">and you lose your footing,</span> slipping on the ice.<<gstress>><<gpain>><<stress 6>><<pain 4>>
+		바람이 더욱 세게 불어친다. <span class="red">당신은 그만 발을 헛디딘다.</span> 당신은 얼음 위로 미끄러지며 넘어진다. <<gstress>><<gpain>><<stress 6>><<pain 4>>
 		<br><br>
 	<</if>>
 	<<destination_lake_ice>>
 <<elseif $rng gte 61>>
-	You're struck by a sudden terror. <span class="pink">You feel watched.</span>
+	당신은 갑작스러운 공포에 휩싸인다. <span class="pink">당신은 감시당하는 기분이 든다.</span>
 	<<if $laketeenspresent is 1>>
-		The voices of the teens fade, until you're alone.
+		십대들의 목소리는 당신이 혼자 남을 때까지 희미해져간다.
 	<</if>>
 	<br><br>
-	There's something below.
+	밑에 뭔가가 있다.
 	<br><br>
 
-	<<link [[Ignore|Lake Ice Ignore]]>><<def 1>><</link>><<willpowerdifficulty 1 $willpowermax>>
+	<<link [[무시한다|Lake Ice Ignore]]>><<def 1>><</link>><<willpowerdifficulty 1 $willpowermax>>
 	<br>
-	<<link [[Look down|Lake Ice Look]]>><</link>>
+	<<link [[내려다본다|Lake Ice Look]]>><</link>>
 	<br>
 <<elseif $rng gte 41>>
-	You hear a heavy groan. Then another. The ice might be unsafe.
+	당신은 거친 신음소리가 들린다. 그리고 이 얼음은 안전하지 않을 수 있다.
 	<br><br>
 
-	<<link [[Be careful (0:10)|Lake Ice Careful]]>><</link>>
+	<<link [[조심한다 (0:10)|Lake Ice Careful]]>><</link>>
 	<br>
-	<<link [[Walk normally|Lake Ice Normal]]>><</link>>
+	<<link [[평범하게 걷는다|Lake Ice Normal]]>><</link>>
 	<br>
 <<elseif $rng gte 21>>
 	<<if $weather is "snow">>
-		The snow falls heavy, and conceals the trees around the lake.
+		눈이 많이 내리면서 호수 주변의 나무들을 가린다.
 		<<if $history gte random(1, 1000)>>
 			<span class="green">It soon passes.</span>
 			<br><br>
 		<<else>>
-			Without the trees to orient yourself, <span class="red">you lose your direction,</span> though the heavy snow soon passes.<<gstress 6>>
+			방향을 알려주는 나무가 없어, 당신은 폭설이 지나갔지만 <span class="red">방향을 찾을 수 없다.</span><<gstress 6>>
 			<br><br>
 		<</if>>
 	<<elseif $weather is "clear">>
 		<<if $daystate is "night">>
 			<<if $moonstate is "evening" and $hour gte 21 or $moonstate is "morning" and $hour lte 6>>
-				The red moon reflects off the ice. Dread stabs at you.<<gtrauma>><<gstress>><<trauma 6>><<stress 6>>
+				붉은 달이 얼음에 비친다. 두려움이 당신을 찌른다.<<gtrauma>><<gstress>><<trauma 6>><<stress 6>>
 				<br><br>
 			<<else>>
-				The moon reflects off the ice. It's cold and beautiful.<<lstress>><<stress 6>>
+				달이 얼음에 비춰진다. 차갑고 아름답다.<<lstress>><<stress 6>>
 				<br><br>
 			<</if>>
 		<<else>>
-			The sun's glare reflects off the ice. You shield your eyes.
+			태양의 눈부신 빛이 얼음에서 반사된다. 당신은 눈을 가린다.
 			<br><br>
 		<</if>>
 	<<else>>
 		<<if $daystate is "night">>
-			You see a fox rummaging in the snow at the lake's edge. It's ears perk, and it bounds between the trees.
+			당신은 호수의 가장자리에서 여우가 눈 속을 뒤지는 것을 지켜본다. 귀가 쫑긋 서더니, 이내 나무 사이로 달아난다.
 			<br><br>
 		<<else>>
-			The surrounding trees are almost invisible in the dark.<<gstress>><<stress 6>>
+			주변의 나무들은 어둠 속에서 거의 보이지 않는다.<<gstress>><<stress 6>>
 			<br><br>
 		<</if>>
 	<</if>>
 	<<destination_lake_ice>>
 <<else>>
-	You slip on the ice!<<gstress>><<stress 6>>
+	당신의 얼음 위에서 미끄러졌다!<<gstress>><<stress 6>>
 	<br><br>
 
-	<<link [[Brace yourself|Lake Ice Brace]]>><<status -10>><</link>><<if $laketeenspresent is 1 and $bus is "lakeshallows">><<lcool>><</if>><<gstress>>
+	<<link [[의지를 다진다|Lake Ice Brace]]>><<status -10>><</link>><<if $laketeenspresent is 1 and $bus is "lakeshallows">><<lcool>><</if>><<gstress>>
 	<br>
-	<<link [[Try to stay upright|Lake Ice Stay]]>><</link>><<dancedifficulty 1 600>>
+	<<link [[똑바로 걷기 위해 노력한다|Lake Ice Stay]]>><</link>><<dancedifficulty 1 600>>
 	<br>
 <</if>>
 <</widget>>
 
 <<widget "destination_lake_ice">>
 <<if $bus is "lakedepths">>
-	<<link [[Next|Lake Depths Ice]]>><<set $eventskip to 1>><</link>>
+	<<link [[다음|Lake Depths Ice]]>><<set $eventskip to 1>><</link>>
 	<br>
 <<else>>
-	<<link [[Next|Lake Shallows Ice]]>><<set $eventskip to 1>><</link>>
+	<<link [[다음|Lake Shallows Ice]]>><<set $eventskip to 1>><</link>>
 	<br>
 <</if>>
 <</widget>>
@@ -271,21 +271,21 @@ Someone screams. Everyone turns and backs away from the newcomer, a <<beasttype>
 <!-- Modified for Monster People -->
 <<if $rng gte 81>>
 <<beastNEWinit 1 boar>>
-You see a <<beasttype>> rifling through litter at the base of a tree. It spots you.
+당신은 <<beasttype_ga>> 나무 밑바닥에서 쓰레기를 뒤지는 것을 본다. 그것이 당신을 발견했다.
 <br><br>
 
-<<link [[Stand your ground|Lake Boar Stand]]>><</link>>
+<<link [[가만히 서 있는다.|Lake Boar Stand]]>><</link>>
 <br>
-<<link [[Run|Lake Boar Run]]>><</link>><<athleticsdifficulty>>
+<<link [[도망친다|Lake Boar Run]]>><</link>><<athleticsdifficulty>>
 <br>
 <<elseif $rng gte 51>>
-You thought you heard someone call your name, but there's no one there.
+당신은 누군가가 당신의 이름을 불렀다고 생각했지만, 주변에는 아무도 없다.
 <<gtrauma>><<trauma 1>>
 <br><br>
 <<set $eventskip to 1>>
 <<destinationlake>>
 <<else>>
-A pair of eyes stares at you from between the trees, then vanishes.
+나무 사이에서 한 쌍의 눈이 당신을 노려보다가 사라진다.
 <<gstress>><<stress 6>>
 <br><br>
 <<set $eventskip to 1>>
@@ -296,7 +296,7 @@ A pair of eyes stares at you from between the trees, then vanishes.
 
 <<widget "meditateoptions">>
 
-<<link [[Still your thoughts (1:00)|Lake Meditate]]>><<pass 60>><<set $phase to 2>><<willpower 1>>
+<<link [[계속 명상한다 (1:00)|Lake Meditate]]>><<pass 60>><<set $phase to 2>><<willpower 1>>
 		<<if $willpower gte (($willpowermax / 7) * 6)>>
 		<<stress -6>><<awareness -2>><<arousal -1200>>
 		<<elseif $willpower gte (($willpowermax / 7) * 5)>>
@@ -316,7 +316,7 @@ A pair of eyes stares at you from between the trees, then vanishes.
 		<br>
 
 <<if $insecurity_penis_tiny gte 1 and $penissize lte 0 and $acceptance_penis_tiny lte 999 and $lake_meditate isnot 1>>
-<<link [[Meditate on your small penis (1:00)|Lake Meditate]]>><<pass 60>><<set $phase to 4>><<willpower 1>><<set $lake_meditate to 1>>
+<<link [[당신의 조그마한 자지를 수용한다 (1:00)|Lake Meditate]]>><<pass 60>><<set $phase to 4>><<willpower 1>><<set $lake_meditate to 1>>
 	<<if $willpower gte (($willpowermax / 7) * 6)>>
 	<<stress 5>><<acceptance "penis_tiny" 20>>
 	<<elseif $willpower gte (($willpowermax / 7) * 5)>>
@@ -336,7 +336,7 @@ A pair of eyes stares at you from between the trees, then vanishes.
 <br>
 <</if>>
 <<if $insecurity_penis_small gte 1 and $penissize is 1 and $acceptance_penis_small lte 999 and $lake_meditate isnot 1>>
-<<link [[Meditate on your small penis (1:00)|Lake Meditate]]>><<pass 60>><<set $phase to 5>><<willpower 1>><<set $lake_meditate to 1>>
+<<link [[당신의 작은 자지를 수용한다 (1:00)|Lake Meditate]]>><<pass 60>><<set $phase to 5>><<willpower 1>><<set $lake_meditate to 1>>
 	<<if $willpower gte (($willpowermax / 7) * 6)>>
 	<<stress 5>><<acceptance "penis_small" 20>>
 	<<elseif $willpower gte (($willpowermax / 7) * 5)>>
@@ -357,7 +357,7 @@ A pair of eyes stares at you from between the trees, then vanishes.
 <</if>>
 <<if $player.gender is "m">>
 	<<if $insecurity_penis_big gte 1 and $penissize gte 4 and $acceptance_penis_big lte 999 and $lake_meditate isnot 1>>
-	<<link [[Meditate on your big penis (1:00)|Lake Meditate]]>><<pass 60>><<set $phase to 6>><<willpower 1>><<set $lake_meditate to 1>>
+	<<link [[당신의 커다란 자지를 수용한다 (1:00)|Lake Meditate]]>><<pass 60>><<set $phase to 6>><<willpower 1>><<set $lake_meditate to 1>>
 		<<if $willpower gte (($willpowermax / 7) * 6)>>
 		<<stress 5>><<acceptance "penis_big" 20>>
 		<<elseif $willpower gte (($willpowermax / 7) * 5)>>
@@ -378,7 +378,7 @@ A pair of eyes stares at you from between the trees, then vanishes.
 	<</if>>
 <<else>>
 	<<if $insecurity_penis_big gte 1 and $penissize gte 2 and $acceptance_penis_big lte 999 and $lake_meditate isnot 1>>
-	<<link [[Meditate on your big penis (1:00)|Lake Meditate]]>><<pass 60>><<set $phase to 6>><<willpower 1>><<set $lake_meditate to 1>>
+	<<link [[당신의 엄청난 자지를 수용한다 (1:00)|Lake Meditate]]>><<pass 60>><<set $phase to 6>><<willpower 1>><<set $lake_meditate to 1>>
 		<<if $willpower gte (($willpowermax / 7) * 6)>>
 		<<stress 5>><<acceptance "penis_big" 20>>
 		<<elseif $willpower gte (($willpowermax / 7) * 5)>>
@@ -399,7 +399,7 @@ A pair of eyes stares at you from between the trees, then vanishes.
 	<</if>>
 <</if>>
 <<if $insecurity_breasts_tiny gte 1 and $breastsize lte 0 and $player.gender is "f" and $acceptance_breasts_tiny lte 999 and $lake_meditate isnot 1>>
-<<link [[Meditate on your flat chest (1:00)|Lake Meditate]]>><<pass 60>><<set $phase to 7>><<willpower 1>><<set $lake_meditate to 1>>
+<<link [[당신의 평평한 가슴을 수용한다 (1:00)|Lake Meditate]]>><<pass 60>><<set $phase to 7>><<willpower 1>><<set $lake_meditate to 1>>
 	<<if $willpower gte (($willpowermax / 7) * 6)>>
 	<<stress 5>><<acceptance "breasts_tiny" 20>>
 	<<elseif $willpower gte (($willpowermax / 7) * 5)>>
@@ -419,7 +419,7 @@ A pair of eyes stares at you from between the trees, then vanishes.
 <br>
 <</if>>
 <<if $insecurity_breasts_small gte 1 and $breastsize gte 1 and $breastsize lte 5 and $acceptance_breasts_small lte 999 and $lake_meditate isnot 1>>
-<<link [[Meditate on your small breasts (1:00)|Lake Meditate]]>><<pass 60>><<set $phase to 8>><<willpower 1>><<set $lake_meditate to 1>>
+<<link [[당신의 약간 작은 가슴을 수용한다 (1:00)|Lake Meditate]]>><<pass 60>><<set $phase to 8>><<willpower 1>><<set $lake_meditate to 1>>
 	<<if $willpower gte (($willpowermax / 7) * 6)>>
 	<<stress 5>><<acceptance "breasts_small" 20>>
 	<<elseif $willpower gte (($willpowermax / 7) * 5)>>
@@ -440,7 +440,7 @@ A pair of eyes stares at you from between the trees, then vanishes.
 <</if>>
 <<if $player.gender is "f">>
 	<<if $insecurity_breasts_big gte 1 and $breastsize gte 8 and $acceptance_breasts_big lte 999 and $lake_meditate isnot 1>>
-		<<link [[Meditate on your big breasts (1:00)|Lake Meditate]]>><<pass 60>><<set $phase to 9>><<willpower 1>><<set $lake_meditate to 1>>
+		<<link [[당신의 커다란 가슴을 수용한다 (1:00)|Lake Meditate]]>><<pass 60>><<set $phase to 9>><<willpower 1>><<set $lake_meditate to 1>>
 		<<if $willpower gte (($willpowermax / 7) * 6)>>
 		<<stress 5>><<acceptance "breasts_big" 20>>
 		<<elseif $willpower gte (($willpowermax / 7) * 5)>>
@@ -461,7 +461,7 @@ A pair of eyes stares at you from between the trees, then vanishes.
 	<</if>>
 <<else>>
 	<<if $insecurity_breasts_big gte 1 and $breastsize gte 6 and $acceptance_breasts_big lte 999 and $lake_meditate isnot 1>>
-	<<link [[Meditate on your big breasts (1:00)|Lake Meditate]]>><<pass 60>><<set $phase to 9>><<willpower 1>><<set $lake_meditate to 1>>
+	<<link [[당신의 엄청난 가슴을 수용한다 (1:00)|Lake Meditate]]>><<pass 60>><<set $phase to 9>><<willpower 1>><<set $lake_meditate to 1>>
 		<<if $willpower gte (($willpowermax / 7) * 6)>>
 		<<stress 5>><<acceptance "breasts_big" 20>>
 		<<elseif $willpower gte (($willpowermax / 7) * 5)>>
@@ -482,7 +482,7 @@ A pair of eyes stares at you from between the trees, then vanishes.
 	<</if>>
 <</if>>
 
-<<link [[Observe your thoughts (1:00)|Lake Meditate]]>><<pass 60>><<set $phase to 3>><<willpower 1>>
+<<link [[생각을 관조한다] (1:00)|Lake Meditate]]>><<pass 60>><<set $phase to 3>><<willpower 1>>
 		<<if $willpower gte (($willpowermax / 7) * 6)>>
 		<<stress 5>><<awareness 2>>
 		<<elseif $willpower gte (($willpowermax / 7) * 5)>>
@@ -500,7 +500,7 @@ A pair of eyes stares at you from between the trees, then vanishes.
 		<</if>>
 		<</link>><<gawareness>><<gstress>><<gwillpower>>
 		<br>
-<<link [[Stop|Lake Fishing Rock]]>><</link>>
+<<link [[멈춘다|Lake Fishing Rock]]>><</link>>
 <br>
 
 <</widget>>
@@ -527,7 +527,7 @@ Swimming sets:
 <<listswimoutfits "school pool">>
 <<storeon "school pool" "check">>
 <<if _store_check is 1>>
-Your clothes lie on a bench.
+당신의 옷이 벤치에 놓여있다.
 <</if>>
 
 <<storeactions "school pool">>


### PR DESCRIPTION
overworld-forest/loc-lake/mason 완료 [ O ]
overworld-forest/loc-lake/widgets 완료 [ O ]
overworld-forest/loc-lake/skating 완료 [ O ]
호수지역 남은 부분 번역완료했습니다.

overworld-forest/loc-lake/skating에서 155줄부분을 제가 맞게 번역한 것인지 헷갈립니다..

그리고 혹시 << he >>이런 것들이 그냥 성별이 정해지지않은 지칭함수(?)면 번역 과정에서 삭제해도 문제가 없을까요?
올린 파일에서는 삭제한 부분이 없으나, 번역으로 옮기는 과정에서 어색한 경우가 생겨서 여쭤봅니다.