### PR TITLE
번역되지 않은 것 때문에 발생하는 버그 해결

### DIFF
--- a/game/base-system/settings.twee
+++ b/game/base-system/settings.twee
@@ -1464,7 +1464,7 @@
 		<<else>>
 			<<set _npcId-->>
 		<</if>>
-		<<if _npcList[$NPCName[_npcId].nam] is undefined>>
+		<<trNamedNPC $NPCName[_npcId].nam>><<if _npcList[_trResult] is undefined>>
 			<<set _npcId-->>
 		<</if>>
 		<<replace #npcSettingsMenu>><<npcSettingsMenu>><</replace>>
@@ -1475,7 +1475,7 @@
 		<<else>>
 			<<set _npcId++>>
 		<</if>>
-		<<if _npcList[$NPCName[_npcId].nam] is undefined>>
+		<<trNamedNPC $NPCName[_npcId].nam>><<if _npcList[_trResult] is undefined>>
 			<<set _npcId++>>
 		<</if>>
 		<<replace #npcSettingsMenu>><<npcSettingsMenu>><</replace>>


### PR DESCRIPTION
네임드 NPC 설정에서 다음/이전이 두 칸씩 이동되는 버그
https://arca.live/b/textgame/64207760