### PR TITLE
Fix APK build using Debian Bullseye

### DIFF
--- a/devTools/androidsdk/image/Dockerfile
+++ b/devTools/androidsdk/image/Dockerfile
@@ -1,21 +1,34 @@
 # IMPORTANT: this is the last debian version to support jdk8
 # As android studio *still* requires 8, be sure to continue using debian:stretch
-FROM node:14.11-stretch
+FROM node:14-bullseye
+
+# Use bash as default shell
+SHELL ["/bin/bash", "-c"] 
 
 # Add backports to make it easier to install npm
 # RUN echo "deb http://deb.debian.org/debian buster-backports main" > /etc/apt/sources.list.d/buster-backports.list
 RUN \
 apt-get update && \
+apt-get upgrade -y && \
 apt-get install -y --no-install-recommends \
     lib32stdc++6 lib32z1 \
-    openjdk-8-jdk-headless \
-    gradle \
-    unzip
+    zip unzip
+
+# Set java and gradle version
+ENV JAVA_VERSION 8.0.372-tem
+ENV GRADLE_VERSION 4.10.3
+# Install it with sdkman
+RUN \
+curl -s "https://get.sdkman.io" | bash && \
+source "$HOME/.sdkman/bin/sdkman-init.sh" && \
+sdk install java ${JAVA_VERSION} && sdk default java ${JAVA_VERSION} && sdk use java ${JAVA_VERSION} && \
+sdk install gradle ${GRADLE_VERSION} && sdk default gradle ${GRADLE_VERSION} && sdk use gradle ${GRADLE_VERSION}
+ENV JAVA_HOME /root/.sdkman/candidates/java/current
 
 WORKDIR /tmp
 ENV ANDROID_HOME /usr/local/android-sdk-linux
 ENV ANDROID_SDK_ROOT ${ANDROID_HOME}
-ENV PATH $PATH:$ANDROID_HOME/cmdline-tools/latest/bin
+ENV PATH $PATH:$ANDROID_HOME/cmdline-tools/latest/bin:/root/.sdkman/candidates/java/current/bin:/root/.sdkman/candidates/gradle/current/bin
 ADD commandlinetools-linux-6609375_latest.zip /tmp/
 RUN unzip /tmp/commandlinetools-linux-6609375_latest.zip
 RUN mkdir -p ${ANDROID_HOME}/cmdline-tools/


### PR DESCRIPTION
1. 임시패치입니다. 누더기 상태이니 나중에 이 파일이 gitgud쪽에서 변경되면 그걸로 덮어쓰길 바랍니다.
2. 빌드가 망가졌던 이유는 기존에 사용된 Debian 9 Stretch가 EoL이 되면서 파일이 전부 내려가서 그렇습니다.
3. Debian 10 Buster 부터는 기본 jdk가 11이 되었습니다. 현 코드는 Android SDK 이슈로 8 이상에서는 작동하지 않습니다.
4. node 14를 지원하는 가장 마지막 Debian 버전인 11 Bullseye를 사용했습니다. 
5. 기존 빌드 환경에 맞추기위해 추가적으로 JDK 8, Gradle 4를 사용했습니다.

PS. 아직 DoL쪽에서는 기 빌드된 도커 이미지를 사용해서 그런지 이슈를 파악 못한듯 합니다.