### PR TITLE
loc-asylum\main.twee 번역

### DIFF
--- a/game/overworld-forest/loc-asylum/main.twee
+++ b/game/overworld-forest/loc-asylum/main.twee
@@ -2572,7 +2572,7 @@
 		더 많은 잡역부들이 환호한다. 그들이 신나게 서로 물건을 주고받는다.
 	<</if>>
 	<br><br>
-	마침내 당신은 의자에서 풀려난다. <<person1>><<person_ gaa>> 말하기 시작한다.
+	마침내 당신은 의자에서 풀려난다. <<person1>><<person_ ga>> 말하기 시작한다.
 	<br><br>
 	<<link [[듣는다|Asylum Fake Treatment Finish]]>><<unset $ft_count>><<unset $ft_five>><<unset $ft_four>><</link>>
 <</if>>

--- a/game/overworld-forest/loc-asylum/main.twee
+++ b/game/overworld-forest/loc-asylum/main.twee
@@ -595,7 +595,7 @@
 :: Asylum Distract
 
 <<set $outside to 0>><<set $location to "asylum">><<asylumeffects>><<effects>>
-You ask for help distracting the orderlies. You have trouble finding anyone who will agree to it, until a <<generate1>><<person1>><<person>>. <<He>> looks at <<his>> friends, then back at you. "Alright," <<he>> says. "We'll make sure you get some proper alone time with the good Doctor." <i>Harper will not receive aid the next time you attack them.</i>
+당신은 잡역부들의 주의를 분산시키는 것을 도와달라고 요청한다. 당신은 이에 동의할 사람을 찾는 데 어려움을 겪다가 한 <<generate1>><<person1>><<person_ ga>> 동의한다. <<He_ ga>> <<his_ yi>> 친구들을 바라보다가 다시 당신을 바라본다. "알겠어," <<he_ ga>> 말한다. "그 훌륭한 의사와 오붓한 시간 충분히 가질 수 있도록 도와줄게." <i>다음번 공격 때 하퍼는 도움을 받지 못할 것이다</i>
 <br><br>
 <<link [[다음|Asylum]]>><<endevent>><</link>>
 <br>
@@ -604,55 +604,55 @@ You ask for help distracting the orderlies. You have trouble finding anyone who 
 
 <<set $outside to 0>><<set $location to "asylum">><<asylumeffects>><<effects>>
 <<generateDoctor 1>><<person1>><<set _towel to random(0,4)>>
-You sneak to a nurse. "Excuse me," you say.
+당신은 간호사에게 살금살금 다가간다. "실례합니다," 당신이 말한다.
 <<if $worn.upper.name is "straightjacket" or $worn.lower.name is "straightjacket bottom">>
-	<<He>> turns, and regards your ruined jacket with a
+	<<He_ ga>> 돌아서서 당신의 망가진 구속복을 보고
 	<<if ($beauty gte ($beautymax / 3) * 2) and _towel lte 1>>
-		smirk. <<covered>> "Can I have some clothes please?"
+		히죽히죽 웃는다. <<covered>> "옷 좀 주시겠어요?"
 		<br><br>
-		"Nah, you're hot." <<He>> pulls out a phone. "I wanna watch you go and ask someone else."
+		"안 돼, 섹시하잖아." <<He_ ga>>가 휴대폰을 꺼낸다. "난 네가 가서 다른 사람에게 물어보는 것을 보고 싶어."
 		<<fameexhibitionism 2 "pic">>
 	<<else>>
-		frown. <<covered>> "Can I have some clothes please?"
+		얼굴을 찌푸린다. <<covered>> "옷 좀 주시겠어요?"
 		<br><br>
-		"How did you manage that? No, never mind. I don't want to know." <<He>> makes a note on a clipboard. "I'll have to inform the doctor."<<set $suspicion += 1>><<gsuspicion>>
+		"어떻게 관리한 거야? 아니, 신경 쓰지 마. 알고 싶지 않아." <<He_ ga>> 클립보드에 메모를 한다. "의사 선생님께 알려야겠어."<<set $suspicion += 1>><<gsuspicion>>
 		<br><br>
-		<<He>> removes the remains of your straightjacket<<if $leftarm is "bound" and $rightarm is "bound">>, letting your arms fall to your sides<</if>>. Your freedom is short-lived as <<he>> forces a fresh one onto you.
+		팔을 옆으로 내리면서 남아있는 구속복 잔해를 제거한다<<if $leftarm is "bound" and $rightarm is "bound">><</if>>. 자유를 만끽하는 것도 잠시, <<he_ ga>> 당신에게 새로운 구속복을 강제로 입힌다.
 		<<bind>><<upperwear 35>><<lowerwear 38>><<fameexhibitionism 1>>
 	<</if>>
 <<elseif ($beauty gte ($beautymax / 3) * 2) and _towel lte 3>> /* 1 in 5 to skip beauty*/
 	<<if _towel is 0>> /*1 in 4 chance*/
-		<<He>> turns, and smiles with open lust when <<he>> sees you. <<covered>> "Can I have some clothes please?"
+		<<He_ ga>> 돌아서서 당신을 보고 욕망에 가득 찬 미소를 짓는다. <<covered>> "옷 좀 주시겠어요?"
 		<br><br>
-		"Nah, you're hot." <<He>> pulls out a phone. "I wanna watch you go and ask someone else."
+		"안 돼, 섹시하잖아." <<He_ ga>>가 휴대폰을 꺼낸다. "난 네가 가서 다른 사람에게 물어보는 것을 보고 싶어."
 		<<fameexhibitionism 2 "pic">>
 	<<else>>
-		<<He>> turns, and smiles with open lust when <<he>> sees you. <<covered>> "Can I have some clothes please?"
+		<<He_ ga>> 돌아서서 당신을 보고 욕망에 가득 찬 미소를 짓는다. <<covered>> "옷 좀 주시겠어요?"
 		<br><br>
-		"Seems like a shame, but sure," <<he>> nods, and wraps some around you.
+		"아쉽지만 물론이지," <<he_ ga>> 고개를 끄덕이며 당신에게 옷을 둘러준다.
 		<<unbind>><<upperwear 87>><<fameexhibitionism 1>>
 	<</if>>
 <<elseif $player.penissize gte 3>>
-	<<He>> turns, and smiles when <<he>> sees you. <<covered>> "Can I have some clothes please?"
+	<<He_ ga>> 돌아서서 당신을 보고 미소 짓는다. <<covered>> "옷 좀 주시겠어요?"
 	<br><br>
-	"One moment," <<he>> says. <<He>> pulls out a phone and takes a quick photo of your <<genitals>>.
-	<<He>> nods at the screen, and then chucks a bundle of fabric at you. "Seems like a damn shame to cover that up."
+	"잠시만," <<he_ ga>> 말한다. <<He_ ga>> 휴대폰을 꺼내서 재빨리 당신의 <<genitals_ rul>> 찍는다.
+	<<He_ ga>> 화면을 보며 고개를 끄덕이더니 당신에게 옷을 던진다. "이걸 감춘다는 건 정말 아쉽네."
 	<<unbind>><<upperwear 87>><<fameexhibitionism 2 "pic">>
 <<elseif $player.breastsize gte 7>>
-	<<He>> turns, and smiles when <<he>> sees you. <<covered>> "Can I have some clothes please?"
+	<<He_ ga>> 돌아서서 당신을 보고 미소 짓는다. <<covered>> "옷 좀 주시겠어요?"
 	<br><br>
-	"One moment," <<he>> says. <<He>> pulls out a phone and takes a quick photo of your <<breasts>>.
-	<<He>> nods at the screen, and then chucks a bundle of fabric at you. "Seems like a damn shame to cover those up."
+	"잠시만," <<he_ ga>> 말한다. <<He_ ga>> 휴대폰을 꺼내서 재빨리 당신의 <<breasts_ ul>> 찍는다.
+	<<He_ ga>> 화면을 보며 고개를 끄덕이더니 당신에게 옷을 던진다. "이걸 감춘다는 건 너무 아쉽네."
 	<<unbind>><<upperwear 87>><<fameexhibitionism 2 "pic">>
 <<elseif _towel gte 2>>
-	<<He>> turns, and seems completely unphased when <<he>> sees you. <<covered>> "Can I have some clothes please?"
+	<<He_ ga>> 돌아서서 당신을 보자 완전히 무표정해진다. <<covered>> "옷 좀 주시겠어요?"
 	<br><br>
-	<<He>> nods, and gives you a patient gown.
+	<<He_ ga>> 고개를 끄덕이며 당신에게 환자복 가운을 건네준다.
 	<<unbind>><<upperwear 87>><<fameexhibitionism 1>>
 <<else>>
-	<<He>> turns, and puts a hand to <<his>> mouth to conceal laughter when <<he>> sees you. <<covered>> "Can I have some clothes please?"
+	<<He_ ga>> 돌아서서 당신을 보자 웃음을 감추기 위해 손으로 입을 가린다. <<covered>> "옷 좀 주시겠어요?"
 	<br><br>
-	<<He>> nods, and gives you a patient gown.
+	<<He_ ga>> 고개를 끄덕이며 당신에게 환자복 가운을 건네준다.
 	<<unbind>><<upperwear 87>><<fameexhibitionism 1>>
 <</if>><br><br><<unset _towel>>
 <<link [[다음|Asylum]]>><<endevent>><</link>>
@@ -666,13 +666,13 @@ You sneak to a nurse. "Excuse me," you say.
 <<elseif $NPCName[$NPCNameList.indexOf("Eden")].love gte 100 and ($edenfreedom is 1 and $edendays gte 2 and !$daily.eden.asylumRescue and $eden_asylum_fence isnot 1 and $leftarm isnot "bound" and $rightarm isnot "bound" and $trauma lte $traumamax / 2) or ($edenfreedom gte 2 and $edendays gte 8 and !$daily.eden.asylumRescue and $eden_asylum_fence isnot 1 and $leftarm isnot "bound" and $rightarm isnot "bound" and $trauma lte $traumamax / 2)>>
 	<<set $eden_asylum_fence to 1>>
 	<<set $daily.eden.asylumRescue to 1>>
-	You see movement among the trees, a lurking figure. It steps closer. <span class="green">It's Eden.</span>
+	당신은 나무 사이에 숨어 있는 형체가 움직이는 것을 본다. 형체가 점점 가까이 다가온다. <span class="green">에덴이다.</span>
 	<br><br>
 
 	<<npc Eden>><<person1>>
-	You jog up to the fence, and lean against it to catch your breath. Eden rushes into full view, emboldened by the sight of you.
+	당신은 울타리까지 뛰어가서 울타리에 기대어 숨을 고른다. 에덴이 당신을 보고 대담해져 시야가 탁트인 곳으로 달려온다.
 	<br><br>
-	<<He>> reaches through the bars and takes your hands. "I'm going to make a distraction," <<he>> says. "In a few minutes you'll hear an explosion on the other side of the building. Climb over the fence, and I'll lead you back to the cabin with me. Got it?"<<takeHandholdingVirginity "Eden" "romantic">>
+	<<He_ ga>> 창살 사이로 손을 뻗어 당신의 손을 잡는다. "내가 주의를 분산시킬게," <<he_ ga>> 말한다. "몇 분 후면 건물 반대편에서 폭발음이 들릴 거야. 그때 울타리를 뛰어넘으면 내가 오두막으로 데려다줄게. 알겠지?"<<takeHandholdingVirginity "Eden" "romantic">>
 	<br><br>
 
 	<<link [[동의한다|Eden Distraction Plan]]>><</link>>
@@ -680,45 +680,45 @@ You sneak to a nurse. "Excuse me," you say.
 	<<link [[거절한다|Eden Distraction Refuse]]>><</link>>
 	<br>
 <<elseif $exposed is 2>>
-	<<flaunting>> you run around the asylum grounds. Security keeps a close eye on you, and warn you off when you jog too close to the perimeter fence.
+	<<flaunting>> 당신은 정신병원 운동장을 뛰어다닌다. 경비원들이 당신을 예의주시하고 있으며 당신이 주변의 울타리에 너무 가까이 가자 경고를 보낸다.
 	<<athletics 3>><<physique 3>>
 	<br><br>
-	Your <<lewdness>> on display makes you the centre of attention.
+	당신이 <<lewdness_ rul>> 드러내자 사람들의 이목이 집중된다.
 	<<exhibitionism5>>
 	<<asylumevents>>
 <<elseif $exposed is 1>>
-	<<flaunting>> you run around the asylum grounds. Security keeps a close eye on you, and warn you off when you jog too close to the perimeter fence.
+	<<flaunting>> 당신은 정신병원 운동장을 뛰어다닌다. 경비원들이 당신을 예의주시하고 있으며 당신이 주변의 울타리에 너무 가까이 가자 경고를 보낸다.
 	<<athletics 3>><<physique 3>>
 	<br><br>
-	Your <<lewdness>> on display makes you the centre of attention.
+	당신이 <<lewdness_ rul>> 드러내자 사람들의 이목이 집중된다.
 	<<exhibitionism3>>
 	<<asylumevents>>
 <<else>>
 	<<if $leftarm is "bound" and $rightarm is "bound" and $worn.upper.name is "straightjacket">>
-		Despite the straightjacket, you persist in running around the asylum grounds.
+		당신은 구속복을 입었음에도 불구하고 정신병원을 계속 뛰어다닌다.
 		<<if currentSkillValue('danceskill') + currentSkillValue('athletics') gte 1600>>
-			With your agile and athletic movement, you make it an excellent training session.
+			당신의 민첩하고 탄탄한 동작으로 훌륭한 운동을 해낸다.
 			<<athletics 2>><<physique 5>>
 		<<elseif currentSkillValue('danceskill') + currentSkillValue('athletics') gte 1100>>
-			With your skillful movement, you can still get a decent training session.
+			당신의 숙련된 움직임으로 적절한 운동을 해낸다.
 			<<athletics 2>><<physique 4>>
 		<<elseif currentSkillValue('danceskill') + currentSkillValue('athletics') gte 650>>
-			It's tricky but thanks to your reasonable agility and athleticism you can still get some kind of workout.
+			힘들지만 적당한 민첩성과 움직임 덕분에 어느 정도 운동을 해낸다.
 			<<athletics 2>><<physique 2>>
 		<<else>>
-			You <<print either("almost immediately","soon")>>
-			<<if random(0,1)>>trip over a root and end up doing a sliding face-plant along the ground.
-			<<else>>trip on a stone and, off-balance, run face-first into a tree. Stunned, you fall back on the floor.
+			당신은 <<print either("곧바로","곧")>>
+			<<if random(0,1)>>나무뿌리에 걸려 넘어져 바닥을 향해 미끄러지듯 엎어진다.
+			<<else>>돌에 걸려 균형을 잃고 넘어지면서 나무에 얼굴을 들이받는다. 당신은 기절하여 바닥에 쓰러진다.
 			<</if>>
-			Several people clap.<<gpain>><<pain 6>><br>
-			Someone eventually helps you up. It wasn't much of a work out.
+			여러 사람들이 박수를 친다.<<gpain>><<pain 6>><br>
+			마침내 누군가가 당신을 일으켜 준다. 별로 어려운 운동은 아니였다.
 			<<athletics 3>>
 		<</if>><br><br>
-		Security are amused by the sight of you, but still warn you off when you jog too close to the perimeter fence.
+		경비원들이 당신을 보고 즐거워하면서도 당신이 주변의 울타리에 너무 가까이 접근하면 경고를 보낸다.
 		<br><br>
 		<<asylumevents>>
 	<<else>>
-		You run around the asylum grounds. Security keeps a close eye on you, and warn you off when you jog too close to the perimeter fence.
+		당신은 정신병원 운동장을 뛰어다닌다. 경비원들이 당신을 예의주시하고 있으며 당신이 주변의 울타리에 너무 가까이 가자 경고를 보낸다.
 		<<athletics 3>><<physique 3>>
 		<br><br>
 		<<asylumevents>>
@@ -728,7 +728,7 @@ You sneak to a nurse. "Excuse me," you say.
 
 :: Eden Asylum Ignore
 <<set $outside to 0>><<set $location to "asylum">><<asylumeffects>><<effects>>
-You decide to ignore the figure and focus on your workout.
+당신은 형체를 무시하고 운동에 집중하기로 결정한다.
 <br><br>
 <<link [[다음|Asylum Exercise]]>><</link>>
 
@@ -736,13 +736,13 @@ You decide to ignore the figure and focus on your workout.
 :: Eden Distraction Refuse
 <<effects>>
 
-당신은 고개를 가로젓는다. "It's too dangerous," you say.
+당신은 고개를 가로젓는다. "너무 위험해요," 당신이 말한다.
 <br><br>
 
-"I'm not letting them keep you," Eden snarls. "But I'll find a safer way if you wish." <<He>> squeezes your hand, then turns and strides into the forest.
+"난 저놈들이 널 가두게 놔두지 않을 거야," 에덴이 으르렁거린다. "하지만 네가 원한다면 더 안전한 방법을 찾아볼게." <<He_ ga>> 당신의 손을 꽉 쥐었다가 돌아서서 숲으로 걸어 들어간다.
 <br><br>
 
-You return to your workout.
+당신은 운동을 재개한다.
 <br><br>
 
 <<link [[다음|Asylum Exercise]]>><<endevent>><</link>>
@@ -753,13 +753,13 @@ You return to your workout.
 <<set $outside to 0>><<set $location to "asylum">><<asylumeffects>><<effects>>
 <<set $daily.eden.distract to 1>>
 <<npc Eden>><<person1>>
-You're about to agree to Eden's plan, but stop when you remember something. "The guard towers," you say. "They'll see me climb the fence."
+에덴의 계획에 동의하려던 순간 당신은 무언가를 떠올리며 멈칫한다. "감시탑," 당신이 말한다. "제가 울타리를 오르는 걸 그들이 보게 될 거예요."
 <br><br>
-Eden's face falls at this realisation. "I'll delay the distraction to <<ampm 21>>," <<he>> says. "They shouldn't see you then."
+에덴의 얼굴이 굳어진다. "주의를 분산시키는 것을 <<ampm 21>>로 미룰게," <<he_ ga>> 말한다. "그럼 네 모습을 보지 못할 거야."
 <br><br>
-"How about their search lights?" you ask.
+"탐조등은 어쩌죠?" 당신이 묻는다.
 <br><br>
-"There has to be a breaker room somewhere providing power. Before the explosion goes off, shut it down and meet me in the forest," <<he>> says, placing a lock pick in your hands and sneaking off.
+"어딘가에 전력을 공급하는 배전실이 있을 거야. 폭발이 일어나기 전에 차단기를 내리고 숲에서 만나자," <<he_ ga>> 말하며 자물쇠따개를 당신의 손에 쥐어주고 몰래 빠져나간다.
 <br><br>
 <<link [[다음|Asylum Exercise]]>><</link>>
 <br>
@@ -770,21 +770,21 @@ Eden's face falls at this realisation. "I'll delay the distraction to <<ampm 21>
 
 <<npc Harper>><<generate2>><<person2>>
 <<bind>><<upperwear 35>>
-You awaken strapped to a bed. A light glares in your eyes. It dims to reveal an old <<person>> in a white coat. Doctor Harper stands beside <<him>>.
+당신은 침대에 묶인 채로 깨어난다. 빛이 환하게 당신의 눈을 비춘다. 빛이 희미해지자 흰 가운을 입은 늙은 <<person_ i>> 보인다. 하퍼 선생님이 <<him_ yi>> 옆에 서있다.
 <br><br>
 
-"No long term effects," The <<person>> says, stepping away.
+"장기적인 효과는 없군," <<person_ ga>> 물러서며 말한다.
 <br>
-"Good," Harper says. "You tried to climb the fence. Do you know how dangerous the forest beyond is? You're here so we can help you. For your own safety."
+"잘 됐네요," 하퍼가 말한다. "넌 울타리를 오르려고 했어. 그 너머의 숲이 얼마나 위험한지 알고 있니? 우리는 널 도와주려고 여기 온 거야. 너의 안전을 위해서."
 <br><br>
 
-You try to stand, but you can't move your arms. "We've given you a jacket until you're a bit better," <<he>> continues, grabbing your shoulder. <<He>> helps you to your feet. You're in a small, dark room.
+당신은 일어서려고 하지만 팔을 움직일 수 없다. "좀 나아질 때까지 구속복을 입도록 하렴." <<he_ ga>> 말을 이으며 당신의 어깨를 잡는다. <<He_ ga>> 당신을 일으켜 세워준다. 당신은 작고 어두운 방에 있다.
 <br><br>
 
-<<He>> steers you towards the door, then through it. You're pushed through another set of doors, into the patients communal area.
+<<He_ ga>> 당신을 문 쪽으로 안내한 다음 밖으로 내보낸다. 당신은 또 다른 문을 지나 환자 공용 구역으로 보내진다.
 <br><br>
 
-"Be well," Harper says, shutting the doors behind you.
+"잘 지내렴," 하퍼가 문을 닫으며 말한다.
 <br><br>
 
 <<link [[다음|Asylum]]>><<endevent>><</link>>
@@ -795,20 +795,20 @@ You try to stand, but you can't move your arms. "We've given you a jacket until 
 :: Asylum Socialise
 
 <<set $outside to 0>><<set $location to "asylum">><<asylumeffects>><<effects>>
-You chat with the other patients.
+당신은 다른 환자들과 대화를 나눈다.
 <<if $exposed is 2>>
-	Your <<lewdness>> on display makes you the centre of attention.
+	당신이 <<lewdness_ rul>> 드러내자 사람들의 이목이 집중된다.
 	<<exhibitionism5>>
 <<elseif $exposed is 1>>
-	Your <<lewdness>> on display makes you the centre of attention.
+	당신이 <<lewdness_ rul>> 드러내자 사람들의 이목이 집중된다.
 	<<exhibitionism3>>
 <<else>>
 <</if>>
 <<if $asylumstatus gte 80>>
-	They're happy to speak with you.
+	그들은 당신과 이야기하게 되어 기쁘다.
 <<elseif $asylumstatus gte 20>>
 <<else>>
-	Most avoid you, but a few are willing to hear you out.
+	대부분은 당신을 피하지만 몇몇은 기꺼이 당신의 이야기를 들어주려 한다.
 <</if>>
 <<generate1>><<person1>><br>
 
@@ -817,135 +817,135 @@ You chat with the other patients.
 	<<set $eden_asylum_window to 1>>
 	<<set $daily.eden.asylumDisarm to 1>>
 	<br>
-	You look out the window, at the trees beyond the fence. You see movement, a figure lurking in the dark. <span class="green">It reminds you of Eden.</span>
+	당신은 창밖으로 울타리 너머의 나무를 바라본다. 당신은 어둠 속에 숨어 있는 형체가 움직이는 것을 본다. <span class="green">에덴이 떠오른다.</span>
 	<br><br>
 	<<endevent>>
 	<<npc Eden>><<person1>>
-	You open the window to get a clearer view. You hear a thud to your right. A bolt sticks out of the brickwork. There's paper wrapped around the shaft.
+	당신은 더 또렷하게 시야를 확보하기 위해 창문을 연다. 오른쪽에서 쿵 하는 소리가 들린다. 화살 하나가 벽돌 벽에 박혀있고 화살대에 종이가 감겨있다.
 	<br><br>
-	You glance behind you to make sure you're not being watched. Everyone seems preoccupied. You pull out the bolt, and unfurl the paper. The handwriting is crude, but legible.
+	당신은 혹시 감시당하고 있지는 않은지 확인하기 위해 뒤를 힐끗 쳐다본다. 모두들 정신이 팔려있다. 당신은 화살을 뽑고 종이를 펼칩니다. 필체는 조잡하지만 읽을 수 있다.
 	<br><br>
-	<i>"I'm coming for you. Mark your window with a towel at <<ampm 22>>. - Eden"</i>
+	<i>"널 데리러 갈게. <<ampm 22>>에 수건으로 창문에 표시해. - 에덴"</i>
 	<br><br>
-	You look back out at the forest, but the figure is gone.
+	당신은 숲을 돌아보지만 그 형체는 이미 사라졌다.
 	<br><br>
 	<<link [[다음|Asylum Eden Towel]]>><<endevent>><</link>>
 
 <<elseif $rng gte 95>>
 	<<if $rng % 2>>
-		"Best keep your nose clean," a <<person>> says. "If the staff are suspicious of you it'll be hard to do anything sneaky."
+		"말썽 피우지 말고 점잖게 행동해," <<person_ ga>> 말한다. "만약 직원들이 널 의심하게 되면 몰래 뭔가 하기가 어려울 거야."
 	<<else>>
-		"Fair warning: it's us against them in here," a <<person>> tells you. "If you cosy up with those guards, nurses and doctors and all the other scum,
-		don't expect any quarter from the rest of us."
+		"미리 경고하는데, 여기선 그들과 우리가 맞붙게 될 거야," <<person_ ga>> 당신에게 말한다. "만약 네가 경비원, 간호사, 의사, 그리고 다른 모든 쓰레기들과 어울린다면,
+		우리한테서 아무것도 기대하지 마."
 	<</if>>
 	<br><br>
 	<<endevent>>
 	<<asylumevents>>
 <<elseif $rng gte 90>>
-	There is a buzz of excitement in the room today. A popular patient has been cured and is being released. Patients crowd by the window
-	waving at a smiling <<person>>, as <<he>> stands with Dr Harper by the driveway.
+	오늘은 방이 흥분으로 들썩이고 있다. 인기가 많던 환자가 완치되어 퇴원하기 때문이다. 환자들이 창가에 모여
+	환하게 웃고 있는 <<personPost "에게">> 손을 흔들고, <<he_ ga>> 하퍼 선생님과 함께 차도 옆에 서 있다.
 	<br><br>
 
-	Moments later, the gates open and a vehicle drives through. It circles round the driveway and stops by the grinning former-patient.
+	잠시 후 정문이 열리고 차 한 대가 들어온다. 차는 진입로를 한 바퀴 돌고 웃고 있는 환자 옆에 정차한다.
 	<<if $rng % 2>>
-		Oddly, the vehicle isn't a taxi or mini-bus. It looks more like an animal-hauler. The driver emerges to greet them.
-		<<if $fluid_forced_stat gte 100>>You recognise the driver from somewhere.<</if>>
-		With a final flurry of waves, the <<person>> is led into the back of the vehicle. A look of confusion finally crosses <<his>> face a moment before
-		<<he>> is hidden behind the closing door.
+		이상하게도 이 차는 택시나 미니버스가 아니다. 동물 운반용 차량처럼 보인다. 운전사가 나와서 승객들을 맞이한다.
+		<<if $fluid_forced_stat gte 100>>당신은 운전사를 어디선가 본 것 같다는 생각이 든다.<</if>>
+		마지막 인사를 하며 <<person_ ga>> 이동한다. <<his_ ga>> 닫히는 문 너머로 사라지는 순간
+		<<he_ yi>> 얼굴이 혼돈에 휩싸인다.
 		<br>
-		The driver bars and padlocks the door.
+		운전사가 차 문을 닫고 자물쇠를 건다.
 		<<if $fluid_forced_stat gte 100>>
-			As the driver talks with Dr Harper, you suddenly remember <<him>> as one of Remy's farmhands.
-			Before you can say anything
+			운전사가 하퍼 선생님과 이야기를 나누는 동안, 당신은 갑작스레 <<him_ ga>> 레미의 농장 일꾼 중 한 명 임을 기억해 낸다.
+			당신이 무언가를 말하기도 전에
 		<<else>>
-			After a brief exchange with Dr Harper
+			하퍼 선생님과의 짧은 대화가 끝나기 무섭게
 		<</if>>
-		the driver clambers into the vehicle and drives away.
+		운전사가 차에 올라타더니 차를 몰고 떠나버린다.
 	<<else>>
-		The <<person>> climbs into the waiting taxi, and waves back through the window. The engine sounds rises and the car pulls away
-		taking the <<person>> back to the town.
+		<<person_ ga>> 대기 중인 택시에 올라타더니 창문 너머로 손을 흔든다. 엔진 소리가 커지고 택시가
+		<<person_ rul>> 태우고 마을로 출발한다.
 	<</if>>
 	<br><br>
-	"Be well," you hear Dr Harper call after the departing vehicle.
+	"잘 지내렴," 당신은 하퍼 선생님이 떠나는 차 뒤로 외치는 것을 듣는다.
 	<br>
-	The watching crowd disperses.
+	지켜보던 사람들이 흩어진다.
 	<br><br>
 	<<endevent>>
 	<<asylumevents>>
 <<elseif $rng gte 85>><<generate2>><<generate3>>
 <br>
-	"Be wary, friend!" a <<person>> fixes your eye. "Beware the door that's ajar!"
+	"조심해, 친구!" <<person_ ga>> 당신의 시선을 사로잡는다. "문틈을 조심해!"
 	<br>
-	"You what, mate?" a <<person2>><<person>> nearby turns to <<person1>><<him>>. "You daft? 'ow can a door be a jar?"
+	"뭐라고, 형씨?" 근처에 있던 <<person2>><<person_ ga>> <<person1>><<him_ rul>> 돌아본다. "너 머리가 텅 비었냐? 어떻게 문이 통일 수 있겠어?"
 	<br>
-	"How can..? It just is. They don't close it properly. Almost like they want the unwary to-"
+	"어떻게...? 그냥 그렇다는 거지. 그들은 문을 제대로 닫지 않는다고. 마치 부주의한 사람들이-"
 	<br>
-	"Totally, man!" a <<person3>><<person>> nearby interrupts. "A door can totally be a jar. Like a giant jar. I mean, like, I never
-	thought of it that way, but the building is like, the cupboard. Full of jars. Which are doors. The door is the jar, literally.
-	And we're the... the jam trying to get out to the town, which is obviously the toast in this... this... ...analogy?
-	I mean, yeah - the door is the jar - I see it. I totally see it." <<He>> sounds quite sure of <<himself>>.
+	"야, 진짜야!" 근처에 있던 <<person3>><<person_ ga>> 끼어든다. "문은 정말로 통이 될 수 있어. 마치 거대한 통처럼 말이야. 내 말은, 난 그런 식으로
+	생각한 적은 없지만 이 건물은 마치 찬장 같아. 통으로 가득 찬 찬장. 그게 문이야. 말 그대로 문이 통이라는 거지.
+	그리고 우리는... 도시로 나가려는 잼이고, 마을은 분명 토스트야... 이... ...이 비유에서는?
+	내 말은, 그래, 문은 통이야 - 이해했어. 완전히 이해했어." <<He_ nun>> 스스로에 대해 상당히 확신하는 것 같다.
 
 	/*Disabled due to feedback
-	The <<person1>><<person>> squints between them, confused. Looking back at you restores <<his>> train of thought.
+	<<person1>><<person_ ga>> 그들 사이에서 혼란스러워하며 눈을 가늘게 뜬다. <<his_ ga>> 당신을 바라보며 생각의 궤도를 되돌린다.
 	<br>
 
-	"Aye, beware that door, friend. Beware its inviting amaranthine glow; beware its seductive fragrance; beware the mellifluous winds that whisper of freedom beyond.
-	For if you pass that door, you'll find that freedom merely a mirage - a phantasm in those endless, shifting plains without."
+	"그래, 저 문을 조심해, 친구. 저 매혹적인 자줏빛과 유혹적인 향기를 조심하고, 저 너머에서 자유를 속삭이는 감미로운 바람을 조심해.
+	그 문을 통과하면 그 자유는 끝없이 변화하는 평원에서 신기루에 불과하다는 것을 알게 될 거야."
 	<br>
-	The <<person2>><<person>> and the <<person3>><<person>> both gaze raptly at the <<person1>><<person>>.
+	<<person2>><<person_ wa>> <<person3>><<person_ ga>> 넋을 잃고 <<person1>><<person_ rul>> 바라본다.
 	<br>
-	"Without what?"
+	"뭐 없이?"
 	<br>
-	"There is no map," <<he>> goes on. "There is no 'right way' that you can learn. There is only Hunger. The endless, voracious hunger of those creatures.
-	Those creatures out there. And if you pass that way, <<if $player.gender_appearance is "f">>girl,<<else>>boy,<</if>> they will have you. This much I know."
+	"지도가 없어," <<he_ ga>> 계속 말한다. "네가 배울 수 있는 '올바른 길'은 없어. 오직 굶주림만이 있을 뿐이야. 저 생명체들의 끝없는, 탐욕스러운 굶주림.
+	그 생명체들이 저 밖에 있어. 만약 네가 저 길을 지나가면, <<if $player.gender_appearance is "f">>얘야,<<else>>얘야,<</if>> 그들이 널 가질거야. 내가 아는 건 이 정도야."
 	<br><br>
 
-	<<He>> looks between <<his>> listeners.
+	<<He_ ga>> 청자들을 번갈아 바라본다.
 	<br>
-	"Most souls who pass that door, wake up back here, broken and abused. Missing a piece. A few never show up. Where do they go? Rumour would have it they escape.
-	Ha! No. No. Know what I think? I think they're Them now. I think, lost in the plains, they eventually surrender to that rapacious hunger and it transforms them.
-	Changes their very beings into those seeping, tentacles of lust. I think they wander the plains still, only now, they search for you."*/
+	"저 문을 통과한 대부분의 영혼들은 깨어나면 부서지고 학대당한 채로 여기로 돌아오게 돼. 뭔가 잃어버린 채로. 몇몇은 아예 돌아오지 않았어. 그들은 어디로 갔을까? 소문에 의하면 탈출했다고 해.
+	하! 아니. 아니야. 내 생각은 뭔지 알아? 그들도 이젠 그놈들이 되었을거야. 평원에서 길을 잃은 그들은 결국 그 탐욕스러운 굶주림에 굴복하고, 그것이 그들을 변화시킨다고 생각해.
+	그들의 존재 자체가 욕망의 촉수로 변해버렸어. 그들은 여전히 평원을 배회하면서 지금은 널 찾아 헤매는 것 같아."*/
 	<br><br>
 	<<endevent>>
 	<<asylumevents>>
 <<elseif $rng gte 80>>
-	"They pump gas into our rooms at night, I swear," a <<person>> says. "Makes us suggestible."
+	"그들은 밤에 우리 방에 가스를 주입해, 맹세하지," <<person_ ga>> 말한다. "우리를 고분고분하게 만든다고."
 	<<if $rng % 2>>
 		<br>
-		"<<print either("Don't need gas to make YOU suggestible!","You're a fine one to talk about making gas!")>>" a voice mutters snidely.
+		"<<print either("가스 따위가 없어도 널 고분고분하게 만들 수 있어!","네가 가스를 만드는 것에 대해 논할 자격이 있냐!")>>" 누군가 비꼬는 듯한 목소리로 중얼거린다.
 		<br>
-		The <<person>> swears at them.
+		<<person_ ga>> 그들을 향해 욕을 한다.
 	<</if>>
 	<br><br>
 	<<endevent>>
 	<<asylumevents>>
 <<elseif $rng gte 75>>
 	<<if $o_long_and_beautiful gte 1 and $o_long_and_beautiful lte 7>><<set $o_long_and_beautiful += 1>>
-		A thin girl with extremely long, messy, tangled hair stands by a window staring at the trees across the garden.
+		매우 길고 지저분하게 헝클어진 머리카락을 가진 마른 소녀가 창가에 서서 정원 건너편 나무를 바라보고 있다.
 		<br>
-		You stand next to her and try to strike up a conversation, but she doesn't respond at all. With her face mostly hidden
-		in a mass of long, tangled hair, it's hard to tell if she even hears you.
+		당신은 그녀 옆에 서서 대화를 시도해 보지만 그녀는 전혀 반응하지 않는다. 그녀는 얼굴의 대부분을
+		길고 헝클어진 머리카락으로 가리고 있어서 당신의 말을 듣고 있는지조차 알 수 없다.
 		<br><br>
 
-		Through the window you notice a small plane passing low over the forest, or maybe the town beyond.
+		창문을 통해 당신은 작은 비행기가 숲 위를 낮게 지나가는 것을 본다. 아니면 그 너머에 있는 마을일지도 모른다.
 		<br>
-		When you glance beside you again, the long-haired girl has vanished.
+		당신이 다시 옆을 쳐다보니 긴 머리 소녀는 어느새 사라져 버렸다.
 	<<else>>
-		A <<person>> stands by a window overlooking the garden and the forest beyond. <<He>> points at a plane.
+		<<person_ ga>> 창가에 서서 정원과 그 너머의 숲을 내려다보고 있다. <<He_ ga>> 비행기를 가리킨다.
 		<br>
-		"So many planes fly over there," <<he>> says. "Every day."
+		"정말 많은 비행기가 저기를 날아다녀," <<he_ ga>> 말한다. "매일."
 		<br><br>
 
-		Sure enough, out the window you notice a small plane passing quite low over the tree line.
+		아니나 다를까, 창밖으로 작은 비행기가 수목선 위로 아주 낮게 지나가는 것이 보인다.
 		<br>
-		"What do you reckon? Is that going over the forest or the town?"
+		"어떻게 생각해? 숲을 지나가는 걸까 아니면 도시를 지나가는 걸까?"
 		<br>
 		<<if currentSkillValue('science') gte 400 and currentSkillValue('maths') gte 600>>
-			You take a couple of steps left and right; make a rough calculation in your head.
+			당신은 좌우로 몇 발자국씩 걸으며 머릿속으로 대략적인 계산을 한다.
 			<br>
-			"Judging by the parallax, probably the town," you say.
+			"시차를 보면 아마 도시일 거예요," 당신이 말한다.
 		<<else>>
-			You shrug.
+			당신은 어깨를 으쓱한다.
 			<br>
 		<</if>>
 		<br>
@@ -956,194 +956,194 @@ You chat with the other patients.
 	<<asylumevents>>
 <<elseif $rng gte 70>>
 	<<if $rng %2>>
-		"I'm not a patient here, y'know? I'm a doctor," a <<person>> says. "I'm telling you I did- I did study in-
-		in- I studied lots of things. So many things. But no one believes me anymore. I came here as a doctor, but now-
-		Now even the other doctors they- they act like I'm a patient. They don't listen. No one listens. I..."
-		<<He>> grips your arm. "I Am Not Crazy."
+		"난 여기 환자가 아니야, 그거 알아? 난 의사야," <<person_ ga>> 말한다. "난 정말- 난 정말 공부를-
+		공부를- 많은 것을 공부했어. 정말 많은 것들을. 하지만 더 이상 아무도 날 믿지 않아. 난 의사로 여기 왔지만 지금은-
+		심지어 다른 의사들도- 그들도 날 환자 취급해. 내 말을 듣지 않아. 아무도 듣지 않아. 난..."
+		<<He_ ga>> 당신의 팔을 잡는다. "난 미치지 않았어."
 	<<else>>
-		"I don't know why I'm here," a <<person>> says. "I remember I got a coach into town. I arrived at the bus station. And I remember I didn't have
-		change for a taxi or bus home. I live near the Temple on Danube Street, so it's not far. Quite a nice walk by the Park, but... I didn't get that far.
-		I remember going out from the station and onto Elk Street... and then...
-		<<print either("","There was a sound and then...","Something... came over a fence and then...","There were guards in uniform, chasing something, and then...")>>
-		I woke up here. They say I did terrible things."
+		"내가 왜 여기 있는지 모르겠어," <<person_ ga>> 말한다. "내가 도시에 과외가 있었다는 것을 기억해. 나는 버스 정류장에 도착했어. 그리고 나에게
+		택시나 버스를 타고 집으로 돌아갈 잔돈이 없었던 게 기억나. 난 다뉴브 거리의 사원 근처에 살고 있어서 그리 멀지 않았어. 공원 옆을 꽤 즐겁게 걷고 있지만... 그리 멀리 가지는 못했어.
+		내가 정류장에서 나와 엘크 가로 갔던 기억이 나... 그러고 나서...
+		<<print either("","소리가 났고...","뭔가가... 울타리를 넘어와서...","유니폼을 입은 경비병들이 무언가를 쫓고 있었어, 그리고...")>>
+		여기서 깨어났어. 내가 끔찍한 일을 저질렀다고 하더라."
 	<</if>>
 	<br><br>
 	<<endevent>>
 	<<asylumevents>>
 <<elseif $rng gte 65>>
-	"I used to work at the school," a <<person>> says.
+	"나는 학교에서 일한 적이 있어," <<person_ ga>> 말한다.
 	<<if $rng %2>>
-		"I heard some disgusting rumours about that headteacher.
-		<<print either("They can't be true. It's probably just students trying to make trouble.","No smoke without fire, I say.","Someone should look into that.")>>"
+		"그 교장에 대한 역겨운 소문을 들었어.
+		<<print either("그럴 리가 없어. 학생들이 문제를 일으키려는 것일 수도 있어.","아니 뗀 굴뚝에서 연기 날 리가 없지.","누군가 조사해 봐야 해.")>>"
 	<<else>>
-		"You should see the disgusting things that history teacher keeps in <<nnpc_his "Winter">> cupboard. One time a student was left in a- well, let's just say that if people knew the truth, <<nnpc_he "Winter">> would probably be sitting here with us."
+		"넌 그 역사 선생이 <<nnpc_his_ yi "Winter">> 찬장에 보관하고 있는 역겨운 물건들을 봐야 해. 한 번은 한 학생이- 음, 만약 사람들이 진실을 알았다면, <<nnpc_he_ nun "Winter">> 아마 우리와 여기에 함께 앉아 있을 걸."
 	<</if>>
 	<br><br>
 	<<endevent>>
 	<<asylumevents>>
 <<elseif $rng gte 60>>
 	<<if $rng % 2>>
-		"Security is tight," a <<person>> says. "No way you're sneaking past them. Not without a distraction."
+		"경비가 삼엄해," <<person_ ga>> 말한다. "경비원들 몰래 빠져나갈 수 있는 방법이 없어. 주의를 분산시키지 않고는 말이야."
 	<<else>>
-		"Sometimes they put me in a straightjacket," a <<person>> says. "I'm so powerless. They can do whatever they want to me."
+		"가끔은 그들이 내게 구속복을 입혀," <<person_ ga>> 말한다. "난 너무 무력해. 놈들이 내게 원하는 건 뭐든지 할 수 있어."
 		<br>
-		<<He>> smiles.
+		<<He_ ga>> 미소 짓는다.
 	<</if>>
 	<br><br>
 	<<endevent>>
 	<<asylumevents>>
 <<elseif $rng gte 55>>
 	<<if $rng % 2>>
-		"Last year the patients were campaigning for a video game system here," a <<person>> says.
-		"<<print either("What's the point of that? Thankfully the doctors said no.","The doctors said it might be disruptive. But it's not like we've got anything better to do here.")>>"
+		"작년에 환자들이 여기서 비디오 게임 행사를 했어," <<person_ ga>> 말한다.
+		"<<print either("그게 무슨 의미가 있을까? 다행히 의사들은 안 된다고 말했어.","의사 말로는 건강에 지장을 줄 수도 있대. 하지만 여기서 우리가 할 수 있는 더 나은 일이 있는 것 같지는 않아.")>>"
 	<<else>>
-		"Sometimes," a <<person>> mutters as much to <<himself>> as you. "I just don't think the police in this town are really looking out for our best interests."
+		"가끔씩," <<person_ ga>> 당신처럼 혼잣말을 중얼거린다. "이 도시의 경찰들은 우리를 보호하지 않는 것 같아."
 	<</if>>
 	<br><br>
 	<<endevent>>
 	<<asylumevents>>
 <<elseif $rng gte 50>>
-	"You're not sick," a <<person>> whispers to you. "None of us are. They're sick. Them.
+	"넌 아프지 않아," <<person_ ga>> 당신에게 속삭인다. "우리 중 아무도. 저놈들이 아픈 거야. 저놈들이.
 	<<if $rng % 2>>
-		They tell us we're sick so they can test their drugs on us. And no one will stop them. It's big pharma. It goes all the way to the top."
+		저놈들은 우리에게 약을 테스트하기 위해 우리가 아프다고 말해. 아무도 저놈들을 막지 않을 거야. 이건 큰 제약회사야. 갈 때까지 갈 거라고."
 	<<else>>
-		They lock people like us up because we're sane. We're a challenge to their power."
+		저놈들은 우리가 제정신이기 때문에 우리 같은 사람들을 가둔 거야. 우리가 저놈들의 권력에게 위협이 되니까."
 	<</if>>
 	<br><br>
 	<<endevent>>
 	<<asylumevents>>
 <<elseif $rng gte 45>>
 	<<if $rng % 2>>
-		"Some of the crazies in here will tell you the staff are all lizard-people bent on world domination."
-		The <<person>> shakes <<his>> head. "What rubbish. They're obviously aliens."
+		"여기 있는 정신 나간 놈들 중 일부는 너에게 직원들이 모두 세계 정복에 혈안이 된 도마뱀 인간들이라고 말할 거야."
+		<<person_ ga>> <<his_ yi>> 고개를 절레절레 흔든다. "무슨 개소리야. 저놈들은 분명히 외계인이야."
 	<<else>>
-		"Some of the nutcases around here will tell you the staff are all aliens preparing us to join a Galactic federation."
-		The <<person>> rolls <<his>> eyes. "Nonsense: they're clearly lizard-people."
+		"여기 미친놈들 중 일부는 너에게 직원들이 모두 은하 연방에 가입할 준비를 하는 외계인이라고 말할 거야."
+		<<person_ ga>> <<his_ yi>> 눈을 굴린다. "어림없는 소리, 저놈들은 확실히 도마뱀 인간이야."
 	<</if>>
 	<br><br>
 	<<endevent>>
 	<<asylumevents>>
 <<elseif $rng gte 40>>
 	<<if $rng % 2>>
-		"It's bad in here," a <<person>> says. "But it's worse out there."
+		"이 안은 상황이 좋지 않아," <<person_ ga>> 말한다. "하지만 밖은 더 나빠."
 	<<else>>
 		<<generate2>><<generate3>>
-		A <<person1>><<person>>, a <<person2>><<person>> and a <<person3>><<person>> plot their escape.
+		<<person1>><<person_ wa>>, <<person2>><<personPost>> 그리고 <<person3>><<person_ ga>> 탈출을 모의한다.
 		<br><br>
-		"How though?" the <<person>> asks. "How are you getting out?"
+		"어떻게?" <<person_ ga>> 묻는다. "어떻게 나갈 거야?"
 		<br>
-		The <<person1>><<person>> looks wildly around the room. "With that thing!" <<he>> points at
-		<<print either("the coffee vendor.","a mysterious machine.","the water fountain.","a heavy wooden desk.")>>
-		"I'm gonna put that through the fuckin' window, that's how!"
+		<<person1>><<person_ ga>> 방 안을 정신없이 둘러본다. "저걸로!" <<he_ ga>>
+		<<print either("커피 노점을 가리킨다.","수상한 기계를 가리킨다.","식수대를 가리킨다.","무거운 목제 책상을 가리킨다.")>>
+		"이걸로 좆같은 창문으로 박살 낼 거야, 그게 방법이야!"
 		<br>
-		"You're going to try to pick that up and throw it through the window?"
+		"저걸 들어서 창문으로 던지겠다고?"
 		<br>
-		"Fuckin' right, I am!" the <<person>> says.
+		"씨발, 그래!" <<person_ ga>> 말한다.
 		<br>
-		"By yourself?" the <<person2>><<person>> asks. "That?"
+		"혼자서?" <<person2>><<person_ ga>> 묻는다. "저걸?"
 		<br>
-		"Didn't I just say I would?"
+		"방금 내가 그러겠다고 말했잖아?"
 		<br>
-		"No way."
+		"말도 안돼."
 		<br>
-		"Bollocks," the <<person3>><<person>> says. "I'll bet an oral fuck you can't do it!"
+		"개소리," <<person3>><<person_ ga>> 말한다. "네가 실패한다에 오랄을 건다!"
 		<br>
-		"What?"
+		"뭐라고?"
 		<br>
-		"Yeah!"
+		"그래!"
 		<br>
-		"What?"
+		"뭐?"
 		<br>
-		"Simple. If you do it I'll <<person1>><<if $NPCList[0].penis isnot "none">>suck you off<<else>>eat you out<</if>> right here," the <<person3>><<person>> says.
-		"No questions. If not, you do the <<if $NPCList[0].pronoun is $NPCList[2].pronoun>>same<<else>>equivalent<</if>> for me."
+		"간단해. 만약 네가 해낸다면 내가 여기서 바로 <<person1>><<if $NPCList[0].penis isnot "none">>빨아줄게<<else>>따먹어 줄게<</if>>," <<person3>><<person_ ga>> 말한다.
+		"질문은 받지 않아. 만약 네가 해내지 못한다면 나에게 <<if $NPCList[0].pronoun is $NPCList[2].pronoun>>똑같은 걸<<else>>동등한 걸<</if>> 해줘."
 		<br>
-		"Okay," the <<person1>><<person>> says. "You're on."
+		"좋아," <<person1>><<person_ ga>> 말한다. "해보자."
 		<br>
-		"Me too," the <<person2>><<person>> says. "I want in on this!"
+		"나도," <<person2>><<person_ ga>> 말한다. "나도 할래!"
 		<br>
-		"More the fuckin' merrier," the <<person1>><<person>> says. "I hope you bitches are ready for a big hairy <<if $NPCList[0].penis isnot "none">>cock<<else>>cunt<</if>> in your face!"
+		"존나 많을수록 좋지," <<person1>><<person_ ga>> 말한다. "이 새끼들아 얼굴에 숱 많은 <<if $NPCList[0].penis isnot "none">>자지<<else>>보지<</if>> 맞이할 준비나 해라!"
 		<br><br>
 
-		A couple of nearby guards watch on with amusement.
+		근처에 있던 두 경비들이 즐거워하며 지켜보고 있다.
 	<</if>>
 	<br><br>
 	<<endevent>>
 	<<asylumevents>>
 <<elseif $rng gte 35>>
 	<<if $rng % 2>>
-		"Hello there," a <<person>> says. "Listen: if you see a patient around here who sounds like they swallowed a dictionary and keeps warning you about things,
-		I need you to punch them for me. I was in a terrible rush this morning and just didn't have the time."
+		"거기 안녕," <<person_ ga>> 말한다. "잘들어, 사전을 삼킨 것 같은 소리를 내며 너에게 뭔가를 계속 경고하는 환자를 보면,
+		나 대신 주먹을 한 방 날려 줘. 오늘 아침에 너무 바빠서 시간이 없었거든."
 	<<else>>
-		"None of this <<print either("matters,","is real,","makes any difference,")>>" a <<person>> says. "We're all just
-		<<print either("living in some future supercomputer's artificial reality","NPCs in someone else's game","characters in a book","ghosts who don't realise we've died","katra passing through the infinite cycle of death and rebirth")>>
-		- but no one recognises the truth."
+		"어느 것도 <<print either("중요하지 않아,","진짜가 아냐,","달라지는 것은 없어,")>>" <<person_ ga>> 말한다. "우리는 모두
+		<<print either("미래의 슈퍼컴퓨터가 만들어낸 가상 현실에 살고 있을 뿐이야","누군가의 게임 속 NPC 들일 뿐이야","책 속의 등장인물일 뿐이야","죽었다는 사실을 모르는 유령일 뿐이야","우리는 모두 죽음과 재생의 영겁의 굴레를 겪는 카트라 일뿐이야")>>
+		- 하지만 아무도 진실을 깨닫지 못해."
 	<</if>>
 	<br><br>
 	<<endevent>>
 	<<asylumevents>>
 <<elseif $o_long_and_beautiful gte 8 and $o_long_and_beautiful lte 9 and $hy_sibling and $hy_parent>> /* approx. 1/3 chance once right stage is reached. */
 	<<generate2>><<set $NPCList[0] to clone($hy_sibling)>><<set $NPCList[1] to clone($hy_parent)>><<person1>>
-	Everyone seems phased out today. No one is talking. As you slump into a chair trying to figure out what to do next,
-	a voice behind you starts singing an upbeat pop song from a year or so ago. <span class="teal">It sounds familiar.</span>
-	You turn around to find a <<person>> smiling at you.
+	오늘은 모두가 기운이 빠져 보인다. 그 누구도 입을 열지 않는다. 당신이 의자에 털썩 주저앉아 다음으로 뭘 해야 할지 한창 고민하던 찰나,
+	뒤에서 누군가가 1년쯤 전 유행했던 경쾌한 팝송을 부르기 시작한다. <span class="teal">익숙한 노래다.</span>
+	뒤돌아보니 <<person_ ga>> 당신을 향해 미소 짓고 있다.
 	<br><br>
-	"I thought that was you," <<he>> says.
+	"너일 줄 알았어," <<he_ ga>> 말한다.
 	<<if $hairlength gte 500>>
-		"I knew I recognised that long, beautiful hair."
+		"그 길고 아름다운 머리카락을 본 순간 알아봤어."
 	<<else>>
-		"Your hair was so long and beautiful. Why did you cut it?"
+		"네 머리카락 정말 길고 아름다웠는데. 왜 잘랐어?"
 	<</if>>
 	<br>
-	After a moment, you place <<him>> as the shy <<person>> who braided your hair on Domus Street a while ago.
-	You hear raised voices from somewhere nearby.
+	잠시 후, 당신은 <<him_ ga>> 얼마 전 도무스 가에서 당신의 머리를 땋아준 수줍은 <<person_ rago>> 생각한다.
+	근처 어딘가에서 고성이 들린다.
 	<br>
-	"So this is where you've been hiding away?" <<he>> says.
+	"여기가 네가 그동안 숨어있던 곳이구나?" <<he_ ga>> 말한다.
 	<<if $chef_state gte 7 and ($chef_rework is undefined or $chef_rework is 0)>>
-		<<if $NPCName[$NPCNameList.indexOf("Sam")].gender>>"That man,<<else>>"That lady,<</if>>
-		Sam, the owner at Ocean Breeze, was offering the orphans money to find you.
-		The customers are furious about the lack of cream buns.
+		<<if $NPCName[$NPCNameList.indexOf("Sam")].gender>>"그 남자,<<else>>"그 여자,<</if>>
+		오션 브리즈의 주인인 샘이 고아들에게 널 찾아달라며 돈을 줬어.
+		고객들이 크림 빵이 부족하다고 화를 내고 있어.
 	<<elseif $orphan_hope gte 25>>
-		"Those orphans were looking for you. Making search parties along the beach.
+		"고아들이 널 찾고 있었어. 해변을 따라 수색대를 만들어서.
 	<<elseif $orphan_hope lte -10>>
-		"I don't blame you. The orphans seem miserable these days.
+		"널 비난하는 건 아냐. 요새 그 고아들 비참해 보였거든.
 	<<elseif $NPCName[$NPCNameList.indexOf("Kylar")].love gte 30 and $NPCName[$NPCNameList.indexOf("Kylar")].state is "active">>
-		"That shy <<nnpc_gendery "Kylar">> you hang out with was skulking around the street looking for you.
+		"너와 같이 놀던 그 수줍음이 많은 <<nnpc_gendery_ ga "Kylar">> 널 찾으러 길거리를 서성이고 있더라.
 	<<elseif $fame.exhibitionism gte 500>>
-		"I think the town's pervs have missed you. Some creep in a car offered me money to strip!
+		"동네 변태들이 널 그리워하는 것 같더라. 차에 탄 어떤 얼간이는 나한테 돈을 줄 테니 옷을 벗으라 했어!
 	<<else>>
-		I thought I hadn't seen you around lately.
+		한동안 널 못 본 것 같은데.
 	<</if>>
-	So have you met my sister? She's here. Very slim, long hair. I told you about her. Attacked at that beach party.
-	She's been here forever now. Her long hair used to be so beautiful but now no one-"
+	그래서 내 여동생은 만나봤어? 걘 지금 여기 있어. 아주 마르고 긴 머리. 내가 걔에 대해 말했잖아. 해변 파티에서 공격당했다고.
+	걘 이제 영원히 여기 있을 거야. 그 애의 긴 머리는 정말 아름다웠는데 지금은 아무도-"
 	<br>
-	The voices behind raise sharply. A <<person2>><<person>> is arguing with one of the orderlies.
+	뒤에서 날카로운 고성이 들린다. <<person2>><<person_ ga>> 한 잡역부와 실랑이를 벌이고 있다.
 	<br><br>
-	"That's <<if $NPCList[0].pronoun is "m">>Dad. He's<<else>>Mum. She's<</if>> telling them to take better care of my sister.
-	She seems to be getting worse again. She blames herself now and thinks she was 'asking for it.' One of the doctors keeps
-	telling her that too. Really upsets her. She doesn't talk to anyone now. Won't even see us anymore. And her hair is nasty now.
-	They don't even brush it. I'd do it, but she won't see me. It's so-"
+	"저 사람은 <<if $NPCList[0].pronoun is "m">>아빠야. 아빠는<<else>>엄마야. 엄마는<</if>> 그들에게 내 여동생을 더 잘 돌보라고 말하는 중이야.
+	그 애의 상태가 다시 나빠지고 있는 것 같거든. 걘 이제 자책하며 스스로 '자초한 일'이라고 생각해. 의사 중 한 명도
+	걔한테 계속 그런 말을 하더라. 그 애를 정말 화나게 했지. 그 애는 이제 누구와도 이야기하지 않아. 더 이상 우릴 만나려고 하지도 않아. 머리도 지저분해졌어.
+	그들은 빗질조차 해주지 않아. 내가 해주고 싶지만 그 애는 날 보지 않으려 해. 이건 정말-"
 	<br><br>
-	"We're leaving," a hand grabs the <<person1>><<persons>> shoulder. "These useless-" The <<person2>><<person>> trails off as <<he>> looks at you.
-	"You? I remember you. With the long hair. You came knocking on our door looking for work. Helped out that time. So you're in here now?!
-	I hope you're okay. And I hope these... people are treating you well. We have to leave now. Good day."
+	"이제 가야 해," 한 손이 <<person1>><<persons_ yi>> 어깨를 잡는다. "이 쓸모없는-" <<person2>><<person_ ga>> 당신과 눈이 마주치자 말을 잇지 못한다.
+	넌? 나 너 기억해. 머리가 길었지. 일거리를 찾으러 우리 집 문을 두드렸잖아. 그때 도와준 적 있었지. 그래서 여기에 온 거야?!
+	네가 무사했으면 좋겠어. 그리고 이... 사람들이 널 잘 대해줬으면 좋겠어. 우린 이제 떠나야 해. 좋은 하루 보내."
 	<br>
-	<<He>> drags the waving <<person1>><<person>> toward the exit.
+	<<He_ ga>> 손을 흔드는 <<person1>><<person_ rul>> 출구 쪽으로 끌고 간다.
 	<br><br>
-	As you watch them leave, you notice a slim girl with long, messy hair watching from the door of the one of the therapy rooms.
-	With a loud buzz, the <<fullGroup>> are let out through a security door.
-	When you look back to the therapy room, the long-haired girl is nowhere to be seen.
+	당신은 떠나는 그들의 모습을 보면서, 치료실 문 앞에서 길고 지저분한 머리를 한 마른 소녀가 지켜보고 있는 것을 발견한다.
+	요란한 소리와 함께 <<fullGroup_ i>> 방범문을 통해 빠져나온다.
+	치료실을 되돌아보니 긴 머리의 소녀는 어디에도 보이지 않는다.
 	<br><br>
-	<span class="teal">Is that the sister?</span><<set $o_long_and_beautiful to 10>>
+	<span class="teal">여동생인 걸까?</span><<set $o_long_and_beautiful to 10>>
 	<br><br>
 	<<endevent>>
 	<<asylumevents>>
 <<elseif $rng gte 30>>
 	<<if $rng % 2>>
-		"Stay out of the empty parts of the building," a <<person>> says. "Someone went there once, and vanished."
+		"건물의 비어 있는 구역에는 접근하지 마," <<person_ ga>> 말한다. "한 번은 누군가 거기 갔다가 사라졌어."
 	<<else>>
-		A <<person>> looks you up and down.
+		<<person_ ga>> 당신을 위아래로 훑어본다.
 		<br>
-		"If anyone attacks you, just let me know," <<he>> smiles. "I like to watch."
+		"누가 널 공격하면 나한테 알려줘," <<he_ ga>> 웃는다. "난 구경하는 거 좋아하거든."
 	<</if>>
 	<br><br>
 	<<endevent>>
@@ -1151,138 +1151,138 @@ You chat with the other patients.
 <<elseif $rng gte 25>>
 	<<if $chef_state gte 3>>
 		<<if $chef_state gte 7 and $rng gte 27>>
-			A <<person>> stares at you open mouthed.
+			<<person_ ga>> 입을 쩍 벌리고 당신을 바라본다.
 			<br>
-			"You're Sam's new chef from Ocean Breeze, aren't you?" <<he>> asks. "Oh my god, I can't believe you're here.
-			I miss those buns! I don't suppose you could make some in here? Could you?!"
+			"샘의 오션 브리즈에 새로 부임한 셰프 맞지?" <<he_ ga>> 묻는다. "세상에, 네가 여기 있다니 믿을 수가 없어.
+			난 그 빵이 너무 그리워! 혹시 여기서 만들어 줄 수 있어? 응?!"
 			<<lstress>><<stress -2>><<asylumstatus 2>><<gcool>>
 		<<else>>
-			"It's funny the things you miss in a place like this," a <<person>> tells you. "I miss the Ocean Breeze Cafe over on Cliff Street.
-			Sam had just hired some new chef who was making the most incredible cream buns."
+			"이런 곳에서 그리운 것들이 있다는 게 참 우습지," <<person_ ga>> 당신에게 말한다. "클리프 가에 있는 오션 브리즈 카페가 너무 그리워.
+			샘이 새로 고용한 셰프가 정말 끝내주는 크림 빵을 만들었거든."
 		<</if>>
 	<<else>>
-		"The one thing I miss," a <<person>> tells you. "Is sitting by the beach watching the swimmers.
-		There's this cafe called the Ocean Breeze there. If you ever get the chance, go. They have delicious cream buns. Ask for Sam."
+		"내가 그리워하는 게 딱 하나 있어," <<person_ ga>> 당신에게 말한다. "해변에 앉아 수영하는 사람들을 구경하는 거.
+		거기에 오션 브리즈라는 카페가 있어. 기회가 된다면 꼭 한번 가봐. 맛있는 크림 빵을 팔거든. 샘에게 부탁해 봐."
 	<</if>>
 	<br><br>
 	<<endevent>>
 	<<asylumevents>>
 <<elseif $rng gte 20>>
 	<<if $rng % 2>>
-		"Don't tell anyone," a <<person>> confides. "But I'm not ill. Not really. I pretend to be because I like it here. It's nice. Crazy would be going back out there."
+		"아무에게도 말하지 마," <<person_ ga>> 은밀히 말한다. "난 아프지 않아. 정말로. 그냥 여기 있는 게 좋아서 아픈 척하고 있는 거야. 여긴 참 좋거든. 미친놈들이나 저기로 돌아갈 거야."
 	<<else>>
-		"I know everyone says this here," a <<person>> says. "But I'm actually not crazy. I'm
-		<<print either("a Detective","a Detective Inspector","a Chief Inspector", "an Officer")>>
-		with the police. Back in the Met I was a big deal. Cracked a few big cases. Newspapers and everything. Was transferred here to clean things up."
+		"여기있는 모두가 그렇게 말하는 것을 알아," <<person_ ga>> 말한다. "하지만 난 사실 미치지 않았어. 나는 경찰 소속
+		<<print either("형사야","수사관이야","경감이야", "장교야")>>
+		경찰청에서 난 거물이었어. 몇 개의 큰 사건을 해결했지. 신문에도 자주 실렸어. 사건을 해결하기 위해 여기로 전출된 거야."
 		<br>
-		<<He>> laughs bitterly.
+		<<He_ ga>> 씁쓸하게 웃는다.
 		<br>
-		"Can you believe that? It's true. We heard rumours about this place. Nasty things. So I was sent here to be the big shining
-		white knight, come to put away the bad guys. Instead they put away me. I have 'PTSD,' apparently."
+		"믿을 수 있겠어? 진짜야. 우린 이곳에 대한 소문을 들었어. 끔찍한 것들. 그래서 난 백마 탄 왕자님이 되어
+		악당들을 쫓아내라고 여기로 보내진 거야. 대신에 그들이 날 쫓아냈지. 난 표면상으론 'PTSD'를 갖고 있어."
 		<br>
-		<<He>> falls silent.
+		<<He_ ga>> 침묵한다.
 		<br><br>
 
-		"Hey!" <<he>> says as you move to leave. "Do me a favour. If you get back out there: never trust the police in this town. There are some good apples,
-		but most are in with the criminals - by the time you know for sure it'll be too late. Like it was for me. Some of the doctors are in on it too.
-		People disappearing."
+		"이봐!" 당신이 떠나려고 하자 <<he_ ga>> 말한다. "부탁 하나만 들어줘. 만약 네가 다시 밖으로 나가게 된다면, 이 도시의 경찰은 절대 믿지 마. 좋은 사람들도 있지만,
+		대부분은 범죄자들과 한통속이야 - 네가 그걸 확실하게 알게 됐을 때는 이미 너무 늦은 거야. 내가 그랬던 것처럼. 일부 의사들도 범죄에 가담하고 있어.
+		사람들이 사라지고 있어."
 	<</if>>
 	<br><br>
 	<<endevent>>
 	<<asylumevents>>
 <<elseif $rng gte 15>>
 	<<if $rng % 2>>
-		"The doctor never calls on me anymore," a <<person>> grumbles. "I haven't had a session in weeks.
+		"의사가 더 이상 날 부르지 않아," <<person_ ga>> 투덜댄다. "몇 주 동안 치료를 받지 못했어.
 		<<if $beauty gte ($beautymax / 3) * 2>>
-			I'll never get better because the doctors are always busy with pretty little things like you."
+			의사들은 항상 너처럼 작고 귀여운 사람들과 있느라 바쁘니까 난 절대 나아질 수 없을 거야."
 			<<gstress>><<stress 1>>
 		<<else>>
-			We should complain! The doctors should help all of us, not just those attractive ones."
+			우리는 항의해야 해! 의사들은 매력적인 사람들만 돕는 게 아니라 우리 모두를 도와야 해."
 		<</if>>
 	<<else>>
-		"That young doctor smelled like cow manure the other afternoon," a <<person>> whispers. "Does <<nnpc_he "Harper">> live on a farm or something!?"
+		"며칠 전 오후에 그 젊은 의사에게서 소 배설물 냄새가 났어," <<person_ ga>> 속삭인다. "혹시 <<nnpc_he_ ga "Harper">> 농장 같은 데서 사나!?"
 	<</if>>
 	<br><br>
 	<<endevent>>
 	<<asylumevents>>
 <<elseif $rng gte 10>>
 	<<if $rng % 2>>/*11 13*/
-		"The doctor makes me do such lewd things," a <<person>> says. "I used to hate it, but now I can't wait for the next treatment."
+		"의사가 내게 야한 짓을 시켰어," <<person_ ga>> 말한다. "예전에는 싫었지만 이제는 다음 치료가 기다려져."
 	<<else>>
-		Everyone is busy with their own activities right now.
+		모든 사람들이 현재 각자 활동하느라 바쁘다.
 		<br><br>
-		As you stand by a window, Dr Harper leads a naked <<personsimple>> into the recreation area.
+		당신이 창문 옆에 서자, 하퍼 선생님이 벌거벗은 <<personsimple_ rul>> 데리고 레크리에이션 구역으로 향한다.
 
-		Completely nude,
+		완전히 벌거벗은 채,
 		<<if $rng gte 14>>/*14*/
-			the <<person>> seems to believe <<he>> is a Doctor. Methodically, Harper leads <<him>> between different patients in the room asking
-			for a medical opinion. The <<person>> refers to an imaginary clipboard as <<he>> pronounces
+			<<person_ nun>> 자신이 의사라고 믿는 것 같다. 하퍼는 체계적으로 <<him_ rul>> 방의 다른 환자들에게 데려가
+			의학적 소견을 묻는다. <<person_ nun>> 가상의 클립보드를 참조하면서
 			<<if currentSkillValue('science') gte 500>>
-				earnest but meaningless pseudo-medical 'diagnoses' for these patients.
+				환자들에게 성실하지만 아무런 의미가 없는 허위 '진단'을 내린다.
 			<<else>>
-				a medical diagnosis for each patient.
+				각 환자마다 의학적인 진단을 내린다.
 			<</if>>
 			<br>
-			Whatever <<he>> says, Harper nods gravely and says, "I see. Thank you, Doctor." And leads <<him>> to another patient.
+			<<he_ ga>> 무슨 말을 하든 하퍼는 진지하게 고개를 끄덕이며 말한다, "그렇군요. 감사합니다, 선생님." 그리고는 <<him_ rul>> 다른 환자에게 데려간다.
 			<br><br>
 
-			After the seventh or eighth patient, they leave together.
+			일곱 또는 여덟 명의 환자를 본 후, 그들은 함께 떠난다.
 		<<else>>/*10 12*/
-			except for a collar connected a lead in Harper's hand, the <<person>> crawls on <<his>> hands and knees, seemingly
-			believing <<he>> is a dog. As Harper leads <<him>> through the room <<he>> tries to crawl under tables and sniff patients'
-			legs.
+			하퍼의 손에 들고있는 목줄 달린 개 목걸이만 착용하고서, <<person_ nun>> 자신이 개라고 믿는 듯 <<his_ yi>> 손과 무릎을 꿇고
+			기어 다니고 있다. 하퍼가 <<him_ rul>> 데리고 방으로 들어가자 <<he_ nun>> 책상 밑을 기어 다니며 환자들의
+			다리 냄새를 맡으려고 한다.
 			<br><br>
 
-			In the middle of the room, Harper unclips the lead from the <<persons>> collar, allowing <<him>> to roam while Harper stops
-			to talk with one of the orderlies. As Harper chats, the <<person>> crawls between patients, getting them to stroke <<his>> head,
-			sniffing their groins, or rolling over so they can rub <<his>> tummy.
+			하퍼가 잡역부 중 한 명과 대화를 나누는 동안 하퍼는 방 중앙에서 <<persons_ yi>> 목줄을 풀고, <<him_ ga>> 방 안을 마음껏
+			방 안을 마음껏 돌아다닐 수 있도록 한다. 하퍼가 대화를 나누는 동안 <<person_ nun>> 환자들 사이를 기어 다니며 <<his_ yi>> 머리를 쓰다듬게 하고,
+			그들의 사타구니 냄새를 맡거나 몸을 뒤집어 <<his_ yi>> 배를 문지르게 한다.
 			<br>
 
-			When
-			<<if $NPCList[0].penis isnot "none">> <<he>> suddenly raises <<his>> leg to pee against
-			<<else>> <<he>> suddenly squats to pee by
+			갑자기
+			<<if $NPCList[0].penis isnot "none">> <<he_ ga>> <<his_ yi>> 다리를 들고 오줌 싸려고 하자
+			<<else>> <<he_ ga>> 책상 옆에 쪼그리고 앉아 오줌을 싸려고 하자
 			<</if>>
-			a table, Harper lunges across and grabs <<his>> collar. "That's enough now."
+			하퍼가 달려와 <<his_ yi>> 목줄을 잡는다. "이제 그만하렴."
 			<br>
-			Harper quickly leads <<him>> from the room.
+			하퍼가 재빨리 <<him_ rul>> 방에서 데리고 나간다.
 		<</if>>
 		<br><br>
-		Many watch with amusement. Some with lust. A few with embarrassment.
+		많은 사람들이 흥미롭게 지켜본다. 일부는 욕망으로. 일부는 당황스러움으로.
 		<br>
-		Absolutely no one seems surprised.
+		확실히 아무도 놀라지 않는 것 같다.
 	<</if>>
 	<br><br>
 	<<endevent>>
 	<<asylumevents>>
 <<elseif $rng gte 5>>
 	<<if $rng % 2>>
-		"That Harper isn't a Doctor," a <<person>> mutters. "Not really. When I first came here Harper was a patient like the rest of us.
-		But now suddenly Harper's our Doctor. THEY all play along, and everyone who might remember has conveniently forgotten. Or disappeared."
+		"하퍼는 의사가 아니야," <<person_ ga>> 중얼거린다. "그렇지 않아. 내가 처음 이곳에 왔을 때 하퍼는 우리와 같은 환자였어.
+		하지만 이젠 갑자기 하퍼가 우리의 의사래. 그들은 모두 한통속이고, 그 사실을 기억할 만한 사람들은 모두 손쉽게 잊어버렸거나 사라졌어."
 		<br>
-		<<He>> looks sharply around.
+		<<He_ ga>> 매섭게 주변을 둘러본다.
 	<<else>>
-		A <<person>> is smiling at you. As you sit near <<him>> you notice one of <<his>> hands is under <<his>> clothes, rhythmically
-		<<if $NPCList[0].penis isnot "none">>rubbing <<his>> dick.<<else>>rubbing <<his>> pussy.<</if>>
+		한 <<person_ ga>> 당신을 향해 미소 짓고 있다. 당신이 <<him_ yi>> 근처에 앉아있을 때 <<his_ ga>> 한 손을 옷 속에 넣고 리드미컬하게
+		<<if $NPCList[0].penis isnot "none">><<his_ yi>> 좆을 문지르는 걸 발견하게 된다.<<else>><<his_ yi>> 보지를 문지르는 걸 발견하게 된다.<</if>>
 		<br><br>
 
-		"Stay right there," <<he>> breathes.
-		<<if $beauty gte ($beautymax / 3) * 2 and $rng % 3>>"Looking at you is helping a lot."
-		<<elseif $player.perceived_breastsize gte 6>><<He>> stares at your <<breasts>> as <<his>> hand moves faster.
-		<<elseif $physique gte ($physiquesize / 7) * 6>>"With those muscles you'd dominate me like the little <<if $NPCList[0].penis isnot "none">>bitch<<else>>whore<</if>> I am."
-		<<elseif $purity lte 400 or $awareness gte 500>>"Talk dirty to me. You look like you've seen it all."
-		<<elseif $beauty lte ($beautymax / 3)>>"Your ugly face'll help me last longer."
-		<<else>>The movement gets faster.
+		"거기 가만히 있어," <<he_ ga>> 숨을 내쉰다.
+		<<if $beauty gte ($beautymax / 3) * 2 and $rng % 3>>"널 보고 있는 것만으로도 많은 도움이 돼."
+		<<elseif $player.perceived_breastsize gte 6>><<He_ ga>> 손을 더 빠르게 움직이면서 당신의 <<breasts_ ul>> 뚫어져라 쳐다본다.
+		<<elseif $physique gte ($physiquesize / 7) * 6>>"그 근육으로 날 마치 <<if $NPCList[0].penis isnot "none">>암캐처럼<<else>>창녀처럼<</if>> 지배해줘."
+		<<elseif $purity lte 400 or $awareness gte 500>>"나한테 야한 말 좀 해봐. 잘 아는 것처럼 보이는데."
+		<<elseif $beauty lte ($beautymax / 3)>>"네 못생긴 얼굴이 내가 더 오래 버티게 해줄 거야."
+		<<else>>움직임이 더 빨라진다.
 		<</if>>
 	<</if>>
 	<br><br>
 	<<endevent>>
 	<<asylumevents>>
 <<else>>
-	"They bind our arms so tight," a <<person>> says.
+	"저놈들이 우리의 팔을 너무 꽉 묶었어," <<person_ ga>> 말한다.
 	<<if $rng % 2>>
-		"Can't do much like that. Not even open our own cupboards."
+		"이러고선 할 수 있는 게 별로 없어. 심지어 찬장도 제대로 열지 못해."
 	<<else>>
-		"Can't even masturbate. Sometimes I have to call to the guards to scratch that itch."
+		"자위조차 제대로 할 수 없어. 가끔씩 경비원을 불러 가려운 곳을 긁어달라고 해야 해."
 	<</if>>
 	<br><br>
 	<<endevent>>
@@ -1292,27 +1292,27 @@ You chat with the other patients.
 :: Asylum Eden Towel
 
 <<set $outside to 0>><<set $location to "asylum">><<asylumeffects>><<effects>>
-You think about the window above your room. Although the bars look unassuming, they're undoubtedly connected to an alarm system.
+당신은 방 위의 창문에 대해 생각한다. 창문은 평범해 보이지만 보이지만 의심할 여지없이 경보 시스템과 연결되어 있을 것이다.
 <br><br>
-It seems that for this plan to work, you'll have to find and disable it.
+이 계획을 실행하려면 해당 경보 시스템을 비활성화해야 한다.
 <br><br>
 <<link [[다음|Asylum]]>><</link>>
 
 :: Asylum Study
 
 <<set $outside to 0>><<set $location to "asylum">><<asylumeffects>><<effects>>
-You read old text books in the dusty library. Most of this should still apply.
+당신은 먼지가 많은 도서관에서 오래된 교과서를 읽는다. 대부분의 내용이 여전히 유효하다.
 <<if $leftarm is "bound" and $rightarm is "bound">>
-	Your arms are bound, so
+	당신의 팔은 묶여있기에,
 	<<if $asylumstatus gte 60>>
-		a nearby patient helps you with turning pages.
+		가까운 환자가 책장을 념겨준다.
 	<<else>>
-		you resort to flipping the pages with your nose.
+		코로 책장을 넘긴다.
 	<</if>>
 <<elseif $asylumstatus gte 80>>
-	Other patients greet you and make space for you at their table.
+	다른 환자들이 당신을 반갑게 맞아주며 자리를 마련해 준다.
 <<elseif $asylumstatus gte 60>>
-	Several nearby patients smile or nod in greeting.
+	주변 몇몇 환자들이 미소를 짓거나 고개를 끄덕이며 반갑게 맞이한다.
 <</if>>
 <br><br>
 
@@ -1320,15 +1320,15 @@ You read old text books in the dusty library. Most of this should still apply.
 	<<pregnancyWatersBrokenPassout "asylumLibrary">>
 <<else>>
 	<<if $exposed is 2>>
-		Your <<lewdness>> on display makes you the centre of attention.
+		당신이 <<lewdness_ rul>> 드러내자 사람들의 이목이 집중된다.
 		<<exhibitionism5>>
 	<<elseif $exposed is 1>>
-		Your <<lewdness>> on display makes you the centre of attention.
+		당신이 <<lewdness_ rul>> 드러내자 사람들의 이목이 집중된다.
 		<<exhibitionism3>>
 	<<else>>
 	<</if>>
 	<<if $rng gte 81>>
-		<<generateDoctor 1>><<person1>>A <<person>> dressed as an orderly stops beside you. "Would you like some assistance?" <<he>> asks.
+		<<generateDoctor 1>><<person1>>잡역부 복장을 한 <<person_ ga>> 당신 옆에 멈춰 선다. "도움이 필요하니?" <<he_ ga>> 묻는다.
 		<br><br>
 		<<link [[받아들인다|Asylum Study Help]]>><<schoolskill>><</link>><<gschool>>
 		<br>
@@ -1342,9 +1342,9 @@ You read old text books in the dusty library. Most of this should still apply.
 :: Asylum Study Help
 
 <<set $outside to 0>><<set $location to "asylum">><<asylumeffects>><<effects>>
-You nod. The orderly pulls a chair close and sits down.
+당신은 고개를 끄덕인다. 잡역부가 의자를 가져와 앉는다.
 <br><br>
-<<He>> helps you with the material. <<Hes>> quite knowledgeable.
+<<He_ ga>> 교재를 가지고 당신을 도와준다. <<Hes_ nun>> 꽤 박식하다.
 <br><br>
 <<link [[감사를 표한다|Asylum Study Thank]]>><<set $suspicion -= 1>><</link>><<lsuspicion>>
 <br>
@@ -1357,14 +1357,14 @@ You nod. The orderly pulls a chair close and sits down.
 
 <<set $outside to 0>><<set $location to "asylum">><<asylumeffects>><<effects>>
 <<if $submissive gte 1150>>
-	"Thank you for the help," you say. "I couldn't have understood it without you."
+	"도움을 주셔서 감사해요," 당신이 말한다. "당신이 없었다면 이해할 수 없었을 거예요."
 <<elseif $submissive lte 850>>
-	"Thanks for the help," you say.
+	"도와줘서 고마워요," 당신이 말한다.
 <<else>>
-	"Thanks," you say. "It's kind of you to help."
+	"고마워요," 당신이 말한다. "정말 친절하시네요."
 <</if>>
 <br><br>
-The <<person>> smiles. "Anytime," <<he>> says. "I need to get back to work. You look after yourself."
+<<person_ ga>> 미소 짓는다. "언제든 물어봐," <<he_ ga>> 말한다. "난 다시 일하러 갈게. 이제 스스로 해봐."
 <br><br>
 <<link [[다음|Asylum]]>><<endevent>><</link>>
 <br>
@@ -1372,7 +1372,7 @@ The <<person>> smiles. "Anytime," <<he>> says. "I need to get back to work. You 
 :: Asylum Study Thigh
 
 <<set $outside to 0>><<set $location to "asylum">><<asylumeffects>><<effects>>
-You rest a hand on their thigh as they explain something to you. Their voice wavers. You ignore their glance in your direction. You keep your focus on the book in front of you, as if nothing were amiss.
+당신은 상대방이 무언가를 설명하는 동안 상대의 허벅지에 손을 얹는다. 상대의 목소리가 흔들린다. 당신은 당신을 향한 상대의 시선을 무시합니다. 당신은 아무 일도 없었다는 듯이 눈앞의 책에 몰두한다.
 <<promiscuity1>>
 <<link [[감사한다|Asylum Study Thank]]>><</link>>
 <br>
@@ -1391,36 +1391,36 @@ You rest a hand on their thigh as they explain something to you. Their voice wav
 <<set $outside to 0>><<set $location to "asylum">><<asylumeffects>><<effects>>
 <<famesex 1>>
 <<if $phase is 0>>
-	You unzip <<his>> fly.
+	당신은 <<his_ yi>> 바지 지퍼를 내린다.
 <<else>>
-	You lift <<his>> skirt.
+	당신은 <<his_ yi>> 치마를 들춘다.
 <</if>>
 <<if $NPCList[0].penis isnot "none">>
 	<<bodyliquid "rightarm" "semen">>
-	<<Hes>> already hard beneath. You run your fingers along <<his>> shaft, and feel <<him>> tremble under your touch. <<He>> shoots furtive glances around the library, but none of the patients or staff have noticed.
+	<<Hes_ yi>> 밑은 벌써 단단해져 있다. 당신은 손가락을 <<his_ yi>> 성기를 따라 움직이며, <<him_ ga>> 당신의 손길에 몸을 부들부들 떠는 것을 느낀다. <<He_ ga>> 도서관 주변을 슬쩍 훑어보지만 환자나 직원 중 누구도 눈치채지 못했다.
 	<br><br>
-	Your fingers reach <<his>> glans, and a moan escapes <<his>> lips. <<He>> presses a hand to <<his>> mouth. <<He>> doesn't last much longer before a wave of pleasure spasms through <<him>> and <<he>> erupts on your hand.
+	당신의 손가락이 <<his_ yi>> 귀두에 닿자, <<his_ yi>> 입술에서 신음 소리가 흘러나온다. <<He_ ga>> 손으로 <<his_ yi>> 입을 막는다. 쾌락의 물결이 <<He_ yi>> 몸에 휘몰아치더니 얼마 지나지 않아 <<him_ nun>> 당신의 손에 사정한다.
 	<br><br>
 <<else>>
-	<<Hes>> already wet beneath. You run your fingers along <<his>> slit, and feel <<him>> tremble under your touch. <<He>> shoots furtive glances around the library, but none of the patients or staff have noticed.
+	<<Hes_ yi>> 밑은 벌써 젖어 있다. 당신은 손가락을 <<his_ yi>> 새를 따라 움직이며, <<him_ ga>> 당신의 손길에 몸을 부들부들 떠는 것을 느낀다. <<He_ ga>> 도서관 주변을 슬쩍 훑어보지만 환자나 직원 중 누구도 눈치채지 못했다.
 	<br><br>
-	Your fingers reach <<his>> clit, and a moan escapes <<his>> lips. <<He>> presses a hand to <<his>> mouth. <<He>> doesn't last much longer before a wave of pleasure spasms through <<him>> and <<he>> cums on your hand.
+	당신의 손가락이 <<his_ yi>> 클리토리스에 닿자, <<his_ yi>> 입술에서 신음 소리가 흘러나온다. <<He_ ga>> 손으로 <<his_ yi>> 입을 막는다. 쾌락의 물결이 <<He_ yi>> 몸에 휘몰아치더니 얼마 지나지 않아 <<him_ nun>> 당신의 손에 정액을 흘린다.
 	<br><br>
 <</if>>
 <<if $phase is 0>>
-	You zip up <<his>> trousers and withdraw your hand.
+	당신은 <<his_ yi>> 바지 지퍼를 올리고 손을 뺀다.
 <<else>>
-	You tug down <<his>> skirt and withdraw your hand.
+	당신은 <<his_ yi>> 치마를 내리고 손을 뺀다.
 <</if>>
 <<if $submissive gte 1150>>
-	"You've been kind to me," you whisper. "It's only fair I'm kind too."
+	"제게 친절하시네요," 당신이 속삭인다. "저도 친절하게 굴어야 공평하죠."
 <<elseif $submissive lte 850>>
-	"Thanks for the help," you whisper.
+	"도와줘서 고마워요," 당신이 속삭인다.
 <<else>>
-	"You helped me," you whisper. "I hope that's thanks enough."
+	"도움이 됐어요," 당신이 속삭인다. "그게 감사의 표시가 되었기를 바라요."
 <</if>>
 <br><br>
-<<He>> nods, still blushing. "I-I need to get back to work," <<he>> says. <<He>> stumbles out of the room.
+<<He_ ga>> 여전히 얼굴을 붉힌 채 고개를 끄덕인다. "ㄴ-난 다시 일하러 가야 겠어," <<he_ ga>> 말한다. <<He_ ga>> 비틀거리며 방을 빠져나간다.
 <br><br>
 <<link [[다음|Asylum]]>><<endevent>><</link>>
 <br>
@@ -1428,40 +1428,40 @@ You rest a hand on their thigh as they explain something to you. Their voice wav
 :: Asylum Breakfast
 
 <<set $outside to 0>><<set $location to "asylum">><<asylumeffects>><<effects>>
-You sit down and enjoy breakfast with the other patients.
+당신은 자리에 앉아 다른 환자들과 함께 아침 식사를 즐긴다.
 <<if $leftarm is "bound" and $rightarm is "bound">>
-	Your arms are bound, so
+	당신의 팔은 묶여있기에,
 	<<if $asylumstatus gte 66>>
-		a nearby patient helps you to eat.
+		주변의 환자가 당신의 식사를 돕는다.
 		<br>
-		"We've got to look out for each other in here."
+		"여기선 서로 돌봐야 해."
 		<br>
 	<<elseif $asylumstatus gte 33>>
-		you find yourself pressing your face against your plate.
+		접시에 얼굴을 바짝 갖다 대고 식사를 한다.
 	<<else>>
-		you find yourself pressing your face against your plate.
-		A person nearby <<print either("grabs your head and pushes your face into your food.","mimics how you're eating while pulling dumb faces.","points at you and laughs.","makes a lewd comment about the way you're eating a sausage.")>>
-		Many others laugh.
+		접시에 얼굴을 바짝 갖다 대고 식사를 한다.
+		근처에 있던 사람이 <<print either("당신의 머리를 잡고 음식에 얼굴을 쑤셔 박는다.","바보 같은 표정을 지으며 당신이 먹는 모습을 흉내낸다.","당신을 가리키며 웃어댄다.","당신이 소시지를 먹는 방식에 대해 음란한 발언을 한다.")>>
+		많은 사람들이 웃는다.
 	<</if>>
 <</if>>
-The food is good, and leaves you feeling warm and happy. It's not just you. The other patients seem more social.
+음식이 맛있어서 당신은 따스하고 행복한 기분을 느낀다. 비단 당신뿐만이 아니다. 다른 환자들은 더 사교적으로 보인다.
 <br><br>
 <<if isPlayerNonparasitePregnancyEnding()>>
 	<<pregnancyWatersBrokenPassout "asylumCafe">>
 <<elseif $exposed is 2>>
-	Your <<lewdness>> on display makes you the centre of attention.
+	당신이 <<lewdness_ rul>> 드러내자 사람들의 이목이 집중된다.
 	<<exhibitionism5>>
 <<elseif $exposed is 1>>
-	Your <<lewdness>> on display makes you the centre of attention.
+	당신이 <<lewdness_ rul>> 드러내자 사람들의 이목이 집중된다.
 	<<exhibitionism3>>
 <<elseif $asylumstatus gte 80>>
-	Other patients seem eager to chat with you.
+	다른 환자들은 당신과 대화하기를 열망하는 것 같다.
 <<elseif $asylumstatus gte 60>>
-	Several nearby patients talk with you over breakfast.
+	주변의 여러 환자들이 아침 식사를 하며 당신과 대화를 나눈다.
 <<elseif $asylumstatus gte 40>>
-	The nearest patients begrudgingly talk with you.
+	가까이에 있던 환자들이 마지못해 대화에 응한다.
 <<else>>
-	However, anything you say is met with stony silence.
+	하지만 당신이 어떤 말을 하든 싸늘한 침묵만이 돌아온다.
 <</if>>
 <br>
 <<asylumevents>>
@@ -1469,18 +1469,18 @@ The food is good, and leaves you feeling warm and happy. It's not just you. The 
 :: Asylum Staff
 
 <<set $outside to 0>><<set $location to "asylum">><<asylumeffects>><<effects>>
-You approach the staff door with a keycard lock.
+당신은 키카드 잠금장치가 있는 직원 출입문에 접근한다.
 <<if $asylumkeycard is 1>>
 	<<if $leftarm is "bound" and $rightarm is "bound">>
-		You have the keycard, but you can't use it with your arms bound.
+		키카드를 가지고 있지만 팔이 묶여 있어서 사용할 수 없다.
 	<<else>>
-		You could open it with the keycard if you wanted.
+		원한다면 키카드로 문을 열 수 있다.
 	<</if>>
 <<else>>
 	<<if $leftarm is "bound" and $rightarm is "bound">>
-		With your arms bound, you couldn't reach it even if you had the keycard.
+		팔이 묶여 있어 키카드가 있어도 손을 뻗을 수 없다.
 	<<else>>
-		If you had the keycard you could open it.
+		키카드가 있다면 문을 열 수 있다.
 	<</if>>
 <</if>>
 <br><br>
@@ -1497,11 +1497,11 @@ You approach the staff door with a keycard lock.
 :: Asylum Open
 
 <<set $outside to 0>><<set $location to "asylum">><<asylumeffects>><<effects>>
-You open the door and peek through.
+당신은 문을 열고 안을 들여다본다.
 <<if $asylumstate is "sleep">>
-	The hallway beyond is dark and empty. You tiptoe through.
+	복도 너머는 어둡고 텅 비어 있다. 당신은 발끝으로 조심스럽게 지나간다.
 	<br><br>
-	You explore the staff area of the asylum, dodging the occasional patrol. You come to a room filled with screens. Cameras showing the inside of each cell. A couple of patients are masturbating.
+	당신은 가끔씩 순찰하는 직원을 피해 정신병원의 직원 구역을 탐색한다. 당신은 화면으로 가득 찬 방에 다다른다. 카메라가 각 감방 내부를 비추고 있다. 두 명의 환자가 자위를 하고 있다.
 	<br><br>
 	화면 하나에 "<span class="red">공기 중 최음제 살포량: 3%</span>" 이라고 적혀 있다. 그 아래엔 아무것도 쓰여 있지 않은 버튼들과 다이얼들이 많이 붙어 있다.
 	<br><br>
@@ -1510,7 +1510,7 @@ You open the door and peek through.
 	<<link [[그만둔다|Asylum]]>><</link>>
 	<br>
 <<else>>
-	The hallway beyond is busy with staff performing their duties. You'll be seen if you stay here. Perhaps it'll be deserted at night.
+	복도 너머는 업무를 처리하느라 분주한 직원들로 붐빈다. 이곳에 계속 머물러 있다면 눈에 띌 것이다. 밤이라면 한산할지도 모른다.
 	<br><br>
 	<<link [[다음|Asylum]]>><</link>>
 <</if>>
@@ -1520,16 +1520,16 @@ You open the door and peek through.
 <<set $outside to 0>><<set $location to "asylum">><<asylumeffects>><<effects>>
 <<if random(1, 1000) lte (currentSkillValue('science') + 100)>>
 	<<if currentSkillValue('science') gte 400>>
-		You try to work out how to operate the machine. There's a logic to it, and through trial and error you discover how to turn up the aphrodisiac. Without warning, an alarm blares. The screen now reads "<span class="red">WARNING Aphrodisiac ministration active: 2000%</span>" You hear shouting.
+		당신은 기계를 작동시키는 방법을 알아내려 한다. 기계에는 일정한 규칙이 있고 여러 시행착오를 거쳐 최음제를 켜는 방법을 알아낸다. 경고 없이 경보가 울려 퍼진다. 이제 화면엔 "<span class="red">경고 최음제 투여 활성화: 2000%</span>" 이라고 표시된다. 고함소리가 들려온다.
 		<br><br>
 	<<else>>
-		You try to work out how to operate the machine. You resort to pushing buttons and turning dials at random. Without warning, an alarm blares. The screen now reads "<span class="red">WARNING Aphrodisiac ministration active: 2000%</span>" You hear shouting.
+		당신은 기계를 작동시키는 방법을 알아내려 한다. 당신은 무작위로 버튼을 누르고 다이얼을 돌리는 데 의존한다. 경고 없이 경보가 울려 퍼진다. 이제 화면엔 "<span class="red">경고 최음제 투여 활성화: 2000%</span>" 이라고 표시된다. 고함소리가 들려온다.
 		<br><br>
 	<</if>>
 	<<link [[다음|Asylum Escape]]>><</link>>
 	<br>
 <<else>>
-	You try to work out how to operate the machine, but it doesn't respond to anything.
+	당신은 기계를 작동시키는 방법을 알아내려고 하지만 아무런 반응이 없다.
 	<br><br>
 	<<if $asylumstate is "sleep">>
 		<<link [[다시 시도한다 (1:00)|Asylum Cameras]]>><<pass 60>><</link>>
@@ -1537,7 +1537,7 @@ You open the door and peek through.
 		<<link [[그만둔다|Asylum]]>><</link>>
 		<br>
 	<<else>>
-		You hear voices outside the room. They pass by, but you'll be discovered soon if you stay. You sneak out.
+		방 밖에서 목소리가 들려온다. 그들은 지나치지만 여기에 계속 머물러 있다가는 금방 발각될 것이다. 당신은 몰래 빠져나온다.
 		<br><br>
 		<<link [[다음|Asylum]]>><</link>>
 		<br>
@@ -1547,11 +1547,11 @@ You open the door and peek through.
 :: Asylum Escape
 
 <<set $outside to 0>><<set $location to "asylum">><<asylumeffects>><<effects>>
-You return to the patient's area, taking cover in alcoves whenever frantic security run by. You arrive, and behold a scene of chaos. Cell doors stand open, their occupants loose. Some members of security have already fallen, their uniforms stripped. Several patients assault each one. Their colleagues try to rescue them, but their batons are no match for the patient's numbers and lust. Many of the patients satisfy themselves with the fallen security personnel, but others fuck each other on tables, chairs or just the floor.
+당신은 정신없이 뛰어다니는 경비원들을 피해 벽감으로 몸을 숨겨가며 환자 구역으로 돌아간다. 당신이 도착했을 때는 이미 모든 것이 아수라장이 되어 있었다. 감방 문은 열려 있고 갇혀 있던 환자들은 모두 풀려나 있다. 일부 경비원들은 이미 유니폼이 벗겨진 채 쓰러져 있다. 여러 명의 환자들이 서로를 공격하고 있다. 경비원들이 동료들을 구출하려 하지만 그들의 곤봉으로는 환자들의 숫자와 욕망을 감당할 수 없다. 대다수의 환자들은 쓰러진 보안 요원을 보며 만족하지만, 다른 환자들은 탁자나 의자 또는 바닥에서 서로를 섹스를 하고 있다.
 <br><br>
-You look out the window. The towers are unmanned and the patrols missing as all hands arrive to contain the threat. Doctor Harper enters from a door opposite, surrounded by security. Now's your chance.
+위협을 막기 위해 모든 인력이 출동하면서 감시탑은 비어 있으며 순찰대도 보이지 않는다. 하퍼 선생님이 경비병들에 둘러싸인 채 반대편 문으로 들어온다. 지금이 절호의 찬스다.
 <br><br>
-You run through the front door unobstructed, and across the grounds. You climb the fence and escape into the forest.
+당신은 아무런 방해도 받지 않고 앞문으로 달려나가 운동장을 가로지른다. 당신은 울타리를 넘어 숲으로 탈출한다.
 <br><br>
 <<endevent>>
 <<asylumescape>>
@@ -1561,7 +1561,7 @@ You run through the front door unobstructed, and across the grounds. You climb t
 :: Asylum Hide
 
 <<set $outside to 0>><<set $location to "asylum">><<asylumeffects>><<effects>>
-You squeeze beneath a chair in the recreation room and wait. The lights turn off, leaving you alone in the dark.
+당신은 레크리에이션 실의 의자 밑에 몸을 웅크리고 기다린다. 불이 꺼지고 어둠 속에 홀로 남겨진다.
 <br><br>
 <<endevent>>
 <<link [[다음|Asylum]]>><</link>>
@@ -1570,18 +1570,18 @@ You squeeze beneath a chair in the recreation room and wait. The lights turn off
 
 <<set $outside to 0>><<set $location to "asylum">><<asylumeffects>><<effects>>
 <<if $rng gte 71>>
-	Harper leads you and the other patients indoors, to the showers. "The water should be on," <<he>> says. "Hygiene is important. I want to see everyone wash."
+	하퍼가 당신과 다른 환자들을 실내의 샤워실로 안내한다. "물은 꼭 틀어놔야 합니다," <<he_ ga>> 말한다. "위생은 중요합니다. 전 여러분이 씻는 모습을 보고 싶어요."
 	<br><br>
-	<<He>> rests a hand on your shoulder as the other patients strip. "As I said, hygiene is important. You wouldn't mind if I take care to personally ensure yours is up to standard?"
+	다른 환자들이 옷을 벗자 <<he_ ga>> 당신의 어깨에 손을 얹는다. "아까도 말했지만 위생은 중요하단다. 내가 직접 너의 위생이 표준에 맞는지 확인해도 괜찮겠니?"
 	<br><br>
 	<<link [[샤워한다|Asylum Shower Accept]]>><<strip>><<wash>><<stress 6>><<arousal 1800>><<set $suspicion -= 1>><<npcincr Harper love 1>><</link>><<exhibitionist1>><<gstress>><<garousal>><<lsuspicion>>
 	<br>
 	<<link [[거부한다|Asylum Shower Refuse]]>><<set $suspicion += 1>><<npcincr Harper love -1>><</link>><<gsuspicion>>
 	<br>
 <<else>>
-	Harper leads you and the other patients indoors, to the showers. "The water should be on," <<he>> says. "Hygiene is important. I want to see everyone wash."
+	하퍼가 당신과 다른 환자들을 실내의 샤워실로 안내한다. "물은 꼭 틀어놔야 합니다," <<he_ ga>> 말한다. "위생은 중요합니다. 전 여러분이 씻는 모습을 보고 싶어요."
 	<br><br>
-	Most of the patients are used to this, and strip without a problem. Some hesitate. Harper sends the orderlies to help them out of their clothes.
+	대부분의 환자들은 이에 익숙해져서 아무런 문제 없이 옷을 벗는다. 일부는 머뭇거린다. 하퍼가 잡역부를 보내 환자들이 옷을 벗는 것을 돕도록 한다.
 	<br><br>
 	<<link [[옷을 벗고 눈에 띄지 않는 곳을 찾는다|Asylum Shower Secluded]]>><<strip>><<wash>><</link>><<exhibitionist1>>
 	<br>
@@ -1596,7 +1596,7 @@ You squeeze beneath a chair in the recreation room and wait. The lights turn off
 :: Asylum Shower Refuse
 
 <<set $outside to 0>><<set $location to "asylum">><<asylumeffects>><<effects>>
-당신은 고개를 가로젓는다. Harper frowns, but doesn't pressure you. <<He>> notices some of the other patients hesitate to undress. <<He>> sends the orderlies to help them out of their clothes.
+당신은 고개를 가로젓는다. 하퍼가 인상을 찌푸리지만 강요하지는 않는다. <<He_ nun>> 몇몇 다른 환자들이 옷을 벗는 것을 망설이는 것을 발견한다. <<He_ ga>> 잡역부를 보내 환자들이 옷을 벗는 것을 돕도록 한다.
 <br><br>
 <<link [[옷을 벗고 눈에 띄지 않는 곳을 찾는다|Asylum Shower Secluded]]>><<strip>><<wash>><</link>><<exhibitionist1>>
 <br>
@@ -1610,20 +1610,20 @@ You squeeze beneath a chair in the recreation room and wait. The lights turn off
 :: Asylum Shower Accept
 
 <<set $outside to 0>><<set $location to "asylum">><<asylumeffects>><<effects>>
-You nod. Harper smiles and begins to disrobe you. <<His>> movements are clinical. <<covered>> <<He>> folds your clothes in a neat pile and picks up a sponge as you step under the shower.
+당신은 고개를 끄덕인다. 하퍼가 미소를 지으며 당신의 옷을 벗기기 시작한다. <<His_ yi>> 움직임은 무미건조하다. <<covered>> <<He_ nun>> 당신의 옷을 깔끔하게 개어 놓고 당신이 샤워실에 들어서자 스펀지를 집어 든다.
 <<exhibitionism1>>
-You stand still as <<he>> scrubs your body from top to bottom, focusing first on your neck, arms, torso, stomach, back, legs, then up to your butt. <<He>> scrubs more softly. You try to breathe normally.
+<<he_ ga>> 당신의 몸을 위에서 아래로 문지르며 목, 팔, 몸통, 배, 등, 다리, 엉덩이까지 닦을 동안 당신은 가만히 서 있는다. <<He_ ga>> 좀 더 부드럽게 문지른다. 당신은 평소와 같이 호흡하려 애쓴다.
 <br><br>
-<<He>> presses the sponge against your <<genitals>>. You stifle a yelp. <<He>> stands right behind you, making sure no one else can see what is happening. Using the sponge <<he>> strokes and massages you, sending waves of pleasure up your spine.
+<<He_ ga>> 스펀지를 당신의 <<genitalsPost "에">> 대고 누른다. 당신은 낑낑거리는 소리를 억누른다. <<He_ ga>> 당신 바로 뒤에 서서 다른 사람들이 무슨 일이 일어나고 있는지 보지 못하게 한다. <<he_ ga>> 스펀지로 당신을 쓰다듬고 마사지하며 쾌락의 파도를 당신의 등줄기에 흘려보낸다.
 <br><br>
-In a moment of weakness you release a sensual sigh. <<He>> places two fingers over your mouth, signalling that you need to keep quiet.
+힘이 빠지는 순간 당신은 야릇한 한숨을 내쉰다. <<He_ ga>> 두 손가락을 당신의 입 위에 얹으며 조용히 하라는 신호를 보낸다.
 <br><br>
 <<if $arousal gte $arousalmax>>
 	<<orgasm>>
-	You arch your back in <<his>> grip, stifling a moan as <<he>> continues to gently massage you mid-orgasm.
+	당신이 <<his_ yi>> 손에 허리를 굽히고 신음을 억누르며 오르가즘을 느끼는 동안 <<he_ ga>> 계속해서 당신을 부드럽게 마사지한다.
 	<br><br>
 <</if>>
-By the time <<he>> stops, your legs feel weak. <<He>> pecks you on the cheek as the bathing session comes to a close.
+<<he_ ga>> 멈출 때쯤 당신의 다리에 힘이 풀린다. 목욕이 끝나자 <<He_ ga>> 당신의 뺨을 가볍게 쪼아댄다.
 <br><br>
 <<link [[다음|Asylum]]>><<clotheson>><<endevent>><</link>>
 <br>
@@ -1631,7 +1631,7 @@ By the time <<he>> stops, your legs feel weak. <<He>> pecks you on the cheek as 
 :: Asylum Shower Secluded
 
 <<set $outside to 0>><<set $location to "asylum">><<asylumeffects>><<effects>>
-You strip slowly, just fast enough to keep the orderlies at bay. By the time your <<lewdness>> is exposed the other patients are already in the showers proper. You follow after them, but find somewhere secluded where you won't be watched. You wash quickly, and get dressed before the other patients finish.
+당신은 잡역부들이 눈치채지 못할 만큼만 천천히 옷을 벗는다. 당신의 <<lewdness_ ga>> 노출될 때쯤엔 다른 환자들은 이미 샤워실에 들어가있다. 당신은 그들을 따라가되, 감시를 받지 않는 한적한 곳을 찾는다. 당신은 다른 환자들이 샤워를 마치기 전에 신속하게 씻고 옷을 입는다.
 <<exhibitionism1>>
 <<endevent>>
 <<link [[다음|Asylum]]>><<clotheson>><</link>>
@@ -1642,62 +1642,62 @@ You strip slowly, just fast enough to keep the orderlies at bay. By the time you
 <<set $outside to 0>><<set $location to "asylum">><<asylumeffects>><<effects>>
 <<generate2>><<generate3>>
 <<if $o_long_and_beautiful gte 1 and $o_long_and_beautiful lte 7 and $rng % 3 == 0>><<set $o_long_and_beautiful += 1>>
-	As you strip, two orderlies, a <<person2>><<person>> and a <<person3>><<person>> march toward a slender girl with long, messy, matted hair sat near you.
+	당신이 옷을 벗자 두 명의 잡역부 <<person2>><<person_ wa>> <<person3>><<person_ ga>> 당신 근처에 앉아 있는 길고 헝클어진 머리카락을 가진 날씬한 소녀를 향해 다가간다.
 	<br>
-	"Strip," the <<person>> barks. "Now."
+	"벗어," <<person_ ga>> 소리친다. "당장."
 	<br>
-	She doesn't move. The <<person2>><<person>> grabs her shoulder and yanks at her top, at which the girl abruptly screeches and claws at the <<persons>> face.
-	The <<person3>><<person>> quickly grabs the girl's hair, firmly yanks back her head and drags her back to the floor. The long-haired girl goes down hard,
-	but then flails frantically on the ground, screeching and clawing in every direction as they struggle to pin her down.
+	그녀는 움직이지 않는다. <<person2>><<person_ ga>> 그녀의 어깨를 잡고 윗도리를 잡아당기자, 소녀는 갑자기 비명을 지르며 <<persons_ yi>> 얼굴을 할퀸다.
+	<<person3>><<person_ ga>> 재빨리 소녀의 머리채를 잡고 머리 뒤로 힘껏 잡아당겨 땅바닥으로 끌어 내린다. 긴 머리의 소녀가 바닥에 힘없이 쓰러지더니
+	그들이 그녀를 붙잡기 위해 안간힘을 쓰자 그녀는 비명을 지르며 바닥에서 미친 듯이 발버둥을 치고 사방으로 할퀴어댄다.
 	<br>
-	You glance at Doctor Harper who is looking anywhere but here right now.
+	당신은 다른 곳을 바라보고 있는 하퍼 선생님을 힐끗 쳐다본다.
 	<br>
-	With the girl pinned, the orderlies start to remove her clothes. Just as abruptly the girl falls silent. Looking down at her, her body has gone limp,
-	tears stream from her eyes as they strip her.
+	잡역부들이 소녀를 고정시킨 채 그녀의 옷을 벗기기 시작한다. 소녀가 갑자기 조용해진다. 그녀를 내려다보니, 그들이 그녀의 옷을 벗기는 동안
+	그녀의 몸이 흐느적거리고 그녀의 눈에서 눈물이 흘러내린다.
 	<br>
-	Dr Harper is still studiously looking elsewhere.
+	하퍼 선생님은 여전히 다른 곳을 주시하고 있다.
 	<br>
-	"Why do you make us do this every time," the <<person2>><<person>> spits as <<he>> removes the last of the girl's underwear. "You think we get off on this?"
+	"왜 매번 이런 일을 하게 만드는 건지," <<person2>><<person_ ga>> 소녀의 마지막 속옷을 벗기면서 뱉는다. "우리가 이런 것에 흥분한다고 생각해?"
 	<br>
-	"And wash your damn hair," the <<person3>><<person>> adds. They shake their heads.
+	"그리고 그 망할 머리도 좀 감아," <<person3>><<person_ ga>> 덧붙여 말한다. 그들은 고개를 가로젓는다.
 	<br>
-	The girl lies completely nude and completely unmoving, tears streaming from empty, vacant eyes.
+	소녀는 완전히 벌거 벗은 채 누워 꼼짝도 하지 않고 텅 빈 눈으로 눈물을 흘리고 있다.
 	<br><br>
 
-	"What are you looking at?" the <<person2>><<person>> glares at you. "Do YOU need our help as well?"
+	"뭘 봐?" <<person2>><<person_ ga>> 당신을 노려본다. "너도 우리의 도움이 필요해?"
 	<br>
 	<<if $submissive gte 1150>>
-		"Sorry," you say, quickly stripping. You run to Harper. "Doctor, is- is it okay if I stay to help that girl. I- I think I know her."
+		"죄송해요," 당신은 재빨리 옷을 벗으며 말한다. 당신은 하퍼에게 달려간다. "선생님, 호- 혹시 제가 여기 남아서 저 여자애를 도와줘도 될까요. 저- 저 여자애를 아는 것 같아요."
 		<br>
-		Harper looks confused at you for a moment. "Yes. Yes, okay. Just make sure you don't miss your wash. Hygiene is important."
+		하퍼가 당신을 보며 잠시 어리둥절한 표정을 짓는다. "그래. 그래, 괜찮아. 씻는 것만 잊지 말렴. 위생은 중요하니까."
 	<<elseif $submissive lte 850>>
-		"DOCTOR Harper," you shout. Harper turns. "I think your two geniuses here
+		"하퍼 선생님," 당신이 소리친다. 하퍼가 돌아본다. "여기 있는 두 천재들이
 		<<if currentSkillValue('science') gte 600>>
-			can't recognise a post-traumatic trigger reaction.
+			외상 후 유발 반응을 인식하지 못하는 것 같아요.
 		<<else>>
-			are just making things worse.
+			상황을 더 악화시키고 있는 것 같아요.
 		<</if>>
-		Can I stay here and look after my friend?"
+		여기 남아서 친구를 돌봐줘도 될까요?"
 		<br>
-		Harper looks confused at you for a moment. "Yes. Yes, okay. Just make sure neither of you miss your wash. Hygiene is important."
+		하퍼가 당신을 보며 잠시 어리둥절한 표정을 짓는다. "그래. 그래, 괜찮아. 둘 다 씻는 것만 잊지 말렴. 위생은 중요하니까."
 	<<else>>
-		You quickly finish stripping and jog across to Harper.
+		당신은 재빨리 옷을 벗고 하퍼에게 달려간다.
 		<br>
-		"Doctor, please. Look at that girl.
-		<<if currentSkillValue('science') gte 600>>That looks like a post-traumatic trigger reaction and <</if>>I think those two are just making things worse.
-		Is it okay if I stay back to help her. I- I think I kind of know her."
+		"선생님, 부탁이에요. 저 여자애 좀 봐주세요.
+		<<if currentSkillValue('science') gte 600>>외상 후 유발 반응처럼 보이고 <</if>>저 둘이 상황을 더 악화시키는 것 같아요.
+		제가 그녀를 돕기 위해 여기 남아 있어도 되나요. 저- 저 그녀를 좀 아는 것 같아요."
 		<br>
-		Harper looks curious for a moment. "Yes. Yes, okay. Just make sure you don't miss your wash. Hygiene is important."
+		하퍼가 잠시 호기심 어린 표정을 짓는다. "그래. 그래, 그러렴. 씻는 것만 잊지 말렴. 위생은 중요하니까."
 	<</if>>
 	<br>
-	Harper signals for the orderlies to leave you alone.
+	하퍼가 잡역부들에게 당신을 내버려 두라는 신호를 보낸다.
 	<<exhibitionism2>>
 	<<endevent>>
 	<<link [[다음|Asylum Shower Wash Hair]]>><</link>>
 <<else>>
-	You strip and enter the showers proper. You stand in the middle of a large room and wash alongside the other patients.
-	You notice a <<person2>><<person>> and <<person3>><<person>> checking you out, but most don't pay you any attention.
-	You head back to your clothes, dry yourself and get dressed.
+	당신은 옷을 벗고 샤워실에 들어간다. 당신은 커다란 방 한가운데 서서 다른 환자들과 함께 씻는다.
+	당신은 <<person2>><<person_ wa>> <<person3>><<person_ ga>> 당신을 살펴보고 있다는 것을 알아챘지만, 대부분은 당신에게 관심을 기울이지 않는다.
+	당신은 다시 옷가지가 있는 곳으로 돌아와 몸을 말리고 옷을 입는다.
 	<<exhibitionism2>>
 	<<endevent>>
 	<<link [[다음|Asylum]]>><<clotheson>><</link>>
@@ -1708,25 +1708,25 @@ You strip slowly, just fast enough to keep the orderlies at bay. By the time you
 :: Asylum Shower Wash Hair
 <<set $outside to 0>><<set $location to "asylum">><<asylumeffects>><<effects>>
 <<pass 25>>
-Completely naked, you sit for a time with the slim, long haired girl. You don't touch her, you just keep quietly talking to her.
+완전히 벗은 채로 당신은 날씬하고 긴 머리의 소녀와 한참 동안 앉아 있는다. 당신은 그녀를 만지지 않고 그저 조용히 그녀에게 말을 건다.
 <<if currentSkillValue('english') gte 500>>
-	After a time, you notice her looking at you. Your eloquence seems to be getting through.
+	잠시 후, 그녀가 당신을 쳐다보고 있는 것을 알아차린다. 당신의 설득력이 빛을 발하는 것 같다.
 	<<if $o_long_and_beautiful lt 9>>
 		<<set $o_long_and_beautiful += 1>>
 	<</if>>
 <<else>>
-	After a time, she seems to come round.
+	한참 후, 그녀는 정신을 차린 것 같다.
 <</if>>
 <br><br>
-Finally, she whispers: "Okay." Together you head to the shower and wash. It is just you two, everyone else finished some time ago. The long-haired girl
+마침내 그녀가 속삭인다. "알았어." 당신 둘은 함께 샤워실로 가서 씻는다. 두 사람을 제외한 나머지 사람들은 모두 한참 전에 샤워를 마쳤다. 긴 머리 소녀는
 <<if $o_long_and_beautiful gte 6>>
-	talks to you a little about her life in the asylum as she washes.
+	씻으면서 정신 병원에서의 삶에 대해 조금 이야기를 한다.
 <<elseif $o_long_and_beautiful gte 4>>
-	washes properly. A few times you think she might be smiling at you.
+	적절히 씻는다. 당신은 그녀가 당신을 향해 방긋 웃은 것 같다고 몇 차례 생각한다.
 <<else>>
-	no longer seems to notice you as she quickly washes.
+	재빨리 몸을 씻느라 더 이상 당신을 주목하지 않는 것 같다.
 <</if>>
-You head back to your clothes, dry yourself and get dressed.
+당신은 다시 옷가지가 있는 곳으로 돌아와 몸을 말리고 옷을 입는다.
 <br><br>
 <<link [[다음|Asylum]]>><<clotheson>><</link>>
 <br>
@@ -1764,37 +1764,37 @@ You head back to your clothes, dry yourself and get dressed.
 
 <<set $outside to 0>><<set $location to "asylum">><<asylumeffects>><<effects>>
 <<if $enemyhealth lte 0>>
-	You push <<him>> away from you. <<He>> looks angry, but soon regains <<his>> composure. "You still have some issues with anger management," <<he>> says. "But that's not why you were here. I'd like to keep seeing you on Fridays, at the hospital. There's a vehicle waiting to take you back to town. Be well."
+	당신은 <<him_ rul>> 밀어낸다. <<He_ nun>> 화가 난 듯 하지만 곧 평정심을 되찾는다. "넌 여전히 분노 조절에 문제가 있구나," <<he_ ga>> 말한다. "하지만 그 점 때문에 여기 온 건 아니지. 매주 금요일마다 병원에서 계속 만났으면 좋겠구나. 도시로 데려다줄 차가 기다리고 있단다. 잘 지내렴."
 	<br><br>
 <<elseif $enemyarousal gte $enemyarousalmax>>
 	<<ejaculation>>
-	<<He>> lies on top of you for a moment, breathing deeply. <<He>> steps away and fixes <<his>> clothing. "T-there's a vehicle waiting to take you back to town. I'd like to keep seeing you on Fridays, at the hospital. Be well."
+	<<He_ ga>> 잠시 당신 위에 누워 숨을 깊게 내쉰다. <<He_ ga>> 한 발짝 물러서서 <<his_ yi>> 옷을 고쳐 입는다. "ㄴ- 널 도시로 데려다 줄 차가 기다리고 있단다. 매주 금요일에 병원에서 계속 만났으면 좋겠구나. 잘 지내렴."
 <<else>>
-	<<He>> looks angry, but soon regains <<his>> composure. "If only I could keep you until I finished the treatment," <<he>> sighs. "There's a vehicle waiting to take you back to town. I'd like to keep seeing you on Fridays, at the hospital. Be well."
+	<<He_ nun>> 화가 난 듯 하지만 곧 평정심을 되찾는다. "치료가 끝날 때까지 널 데리고 있을 수만 있다면," <<he_ ga>> 한숨을 내쉰다. "널 도시로 데려다 줄 차가 기다리고 있단다. 매주 금요일에 병원에서 계속 만났으면 좋겠구나. 잘 지내렴."
 <</if>>
 <br><br>
 <<clothesontowel>>
 <<endcombat>>
 <<if $suspicion gte 80>>
-	A group of orderlies lead you away from Harper's office, through the main area of the asylum.
+	잡역부 무리가 당신을 하퍼의 사무실에서 데리고 나와 정신병원의 주요 구역으로 데려간다.
 <<elseif $suspicion gte 20>>
-	A pair of orderlies lead you away from Harper's office, through the main area of the asylum.
+	두 잡역부가 당신을 하퍼의 사무실에서 데리고 나와 정신병원의 주요 구역으로 데려간다.
 <<else>>
-	A nurse leads you away from Harper's office, through the main area of the asylum.
+	간호사가 당신을 하퍼의 사무실에서 데리고 나와 정신병원의 주요 구역으로 데려간다.
 <</if>>
 <<if $asylumstatus gte 80>>
-	The other patients wave you goodbye.
+	다른 환자들이 당신에게 작별 인사를 한다.
 <<elseif $asylumstatus gte 20>>
-	The other patients ignore you.
+	다른 환자들이 당신을 무시한다.
 <<else>>
-	The other patients sneer at you.
+	다른 환자들은 당신을 비웃는다.
 <</if>>
-You go through a staff door, then through a larger double door and into a waiting car.
+당신은 직원용 문과 더 큰 이중문을 지나 대기 중인 차에 올라탄다.
 <br><br>
-The car starts, and drives through the iron gates into the forest. It's a dark, overgrown road. You don't move very fast. The driver says nothing.
+차가 움직이기 시작하고 철문을 지나 숲으로 들어간다. 도로는 어둡고 수풀이 무성하게 자라고 있기에 빠르게 이동하지 못한다. 운전자는 아무 말도 하지 않는다.
 <br><br>
 <<pass 60>>
-You emerge from the wood far from town, but the road curves north through moor and farmland. You soon arrive back at civilisation. The bustle of Harvest Street greets you. You continue until the orphanage comes into view.
+당신은 도시에서 멀리 떨어진 숲을 빠져나왔지만, 도로는 황무지와 농지를 지나 북쪽으로 굽어 있다. 당신은 곧 문명지에 도착한다. 북적이는 하베스트 가가 당신을 맞이한다. 당신은 고아원이 시야에 들어올 때까지 계속 걷는다.
 <br><br>
 <<asylumend>>
 <<endevent>>
@@ -1803,28 +1803,28 @@ You emerge from the wood far from town, but the road curves north through moor a
 :: Asylum Harper Shove
 
 <<set $outside to 0>><<set $location to "asylum">><<asylumeffects>><<effects>>
-You shove the doctor away from you. <<He>> looks angry, but soon regains <<his>> composure. "You still have some issues with anger management," <<he>> says. "But that's not why you were here. I'd like to keep seeing you on Fridays, at the hospital. There's a vehicle waiting to take you back to town. Be well."
+당신은 의사를 밀어낸다. <<He_ nun>> 화가 난 듯 하지만 곧 평정심을 되찾는다. "넌 여전히 분노 조절에 문제가 있구나," <<he_ ga>> 말한다. "하지만 그 점 때문에 여기 온 건 아니지. 매주 금요일마다 병원에서 계속 만났으면 좋겠구나. 도시로 데려다줄 차가 기다리고 있단다. 잘 지내렴."
 <br><br>
 <<if $suspicion gte 80>>
-	A group of orderlies lead you away from Harper's office, through the main area of the asylum.
+	잡역부 무리가 당신을 하퍼의 사무실에서 데리고 나와 정신병원의 주요 구역으로 데려간다.
 <<elseif $suspicion gte 20>>
-	A pair of orderlies lead you away from Harper's office, through the main area of the asylum.
+	두 잡역부가 당신을 하퍼의 사무실에서 데리고 나와 정신병원의 주요 구역으로 데려간다.
 <<else>>
-	A nurse leads you away from Harper's office, through the main area of the asylum.
+	간호사가 당신을 하퍼의 사무실에서 데리고 나와 정신병원의 주요 구역으로 데려간다.
 <</if>>
 <<if $asylumstatus gte 80>>
-	The other patients wave you goodbye.
+	다른 환자들이 당신에게 작별 인사를 한다.
 <<elseif $asylumstatus gte 20>>
-	The other patients ignore you.
+	다른 환자들이 당신을 무시한다.
 <<else>>
-	The other patients sneer at you.
+	다른 환자들은 당신을 비웃는다.
 <</if>>
-You go through a double door and into a waiting car.
+당신은 이중문을 지나 대기 중인 차에 올라탄다.
 <br><br>
-The car starts, and drives through the iron gates into the forest. It's a dark, overgrown road. You don't move very fast. The driver says nothing.
+차가 움직이기 시작하고 철문을 지나 숲으로 들어간다. 도로는 어둡고 수풀이 무성하게 자라고 있기에 빠르게 이동하지 못한다. 운전자는 아무 말도 하지 않는다.
 <br><br>
 <<pass 60>>
-You emerge from the wood far from town, but the road curves north through moor and farmland. You soon arrive at civilisation. The bustle of Harvest Street greets you. You continue until the orphanage comes into view.
+당신은 도시에서 멀리 떨어진 숲을 빠져나왔지만, 도로는 황무지와 농지를 지나 북쪽으로 굽어 있다. 당신은 곧 문명지에 도착한다. 북적이는 하베스트 가가 당신을 맞이한다. 당신은 고아원이 시야에 들어올 때까지 계속 걷는다.
 <br><br>
 <<asylumend>>
 <<endevent>>
@@ -1835,31 +1835,31 @@ You emerge from the wood far from town, but the road curves north through moor a
 <<set $outside to 0>><<set $location to "home">><<effects>>
 <<if $NPCName[$NPCNameList.indexOf("Robin")].init is 1 and $robinmissing is 0>>
 	<<if $NPCName[$NPCNameList.indexOf("Robin")].trauma gte 80>>
-		You enter the orphanage and head to your room. You don't meet anyone. There's a small cake sat on the windowsill with a note attached.
+		당신은 고아원에 들어가서 당신의 방으로 향한다. 당신은 누구와도 마주치지 못한다. 창틀에 쪽지가 붙어 있는 작은 케이크가 놓여 있다.
 		<br><br>
-		"Welcome home!
+		"돌아온 걸 환영해!
 		<br>
-		- Robin"
+		- 로빈"
 		<br><br>
 	<<elseif $NPCName[$NPCNameList.indexOf("Robin")].trauma gte 20>>
-		You enter the orphanage and head to your room. You find <<npc Robin>><<person1>>Robin waiting. <<He>> jumps to <<his>> feet and hugs you. "Bailey said the hospital phoned," <<he>> says. "They told us you were coming back." <<He>> pulls away and smiles. "They wouldn't let me visit. I got you something." <<He>> drops to <<his>> knees and pulls something out from under your bed. It's a small cake.
+		당신은 고아원에 들어가서 당신의 방으로 향한다. 로빈이 <<npc Robin>><<person1>>당신을 기다리고 있다. <<He_ ga>> 자리에서 벌떡 일어나 당신을 안는다. "베일리가 병원에서 연락이 왔었다고 했어," <<he_ ga>> 말한다. "네가 곧 돌아올 거라고 했어." <<He_ ga>> 뒤로 물러서며 미소를 짓는다. "병원에서 면회를 허락해주지 않더라. 네게 줄 게 있어." <<He_ ga>> 무릎을 꿇고 침대 밑에서 무언가를 꺼낸다. 작은 케이크다.
 		<br><br>
-		"I had to hide it." <<He>> hugs you again. "Welcome home. I missed you."
+		"숨길 수밖에 없었어." <<He_ ga>> 다시 당신을 껴안는다. "돌아온 걸 환영해. 보고 싶었어."
 		<br><br>
-		You chat with <<him>> a while. <<He>> asks about where you stayed. What your room was like, if the food was good, if the people were nice. You're not sure how much to tell <<him>>. "I need to go," <<he>> says after a while. "Bailey gave me chores." <<He>> waves goodbye as <<he>> leaves.
+		당신은 <<him_ wa>> 잠시 대화를 나눈다. <<He_ ga>> 당신이 어디에 있었는지 묻는다. 당신의 방은 어땠는지, 음식은 맛있었는지, 사람들은 친절했는지 묻는다. 당신은 <<himPost "에게">> 어디까지 말해야 할지 확신하지 못한다. "난 가봐야겠어," <<he_ ga>> 한참 뒤 말한다. "베일리가 집안일을 시켰거든." <<He_ ga>> 떠나면서 손을 흔든다.
 		<<ltrauma>><<lstress>><<trauma -12>><<stress -12>>
 		<br><br>
 	<<else>>
-		A face appears in a window as you approach the orphanage. It's Robin. <<npc Robin>><<person1>><<He>> runs at you once you're inside, and almost knocks you over with <<his>> hug. "Bailey said the hospital phoned," <<he>> says. "They told us you were coming back." <<He>> pulls away and smiles. "They wouldn't let me visit. I got you something. Come with me." <<He>> takes your hand and tugs you after <<him>>.
+		고아원에 가까워지자 창문에 익숙한 얼굴이 보인다. 로빈이다. 당신이 안으로 들어서자 <<npc Robin>><<person1>><<He_ ga>> 달려들어 포옹을 하며, 당신을 넘어뜨릴 뻔한다. 베일리가 병원에서 연락이 왔었다고 했어," <<he_ ga>> 말한다. "네가 곧 돌아올 거라고 했어." <<He_ ga>> 뒤로 물러서며 미소를 짓는다. "병원에서 면회를 허락해주지 않더라. 네게 줄 게 있어. 날 따라와." <<He_ ga>> 당신의 손을 잡아당긴다.
 		<br><br>
-		<<He>> drops to <<his>> knees once in your room, and pulls something out from under your bed. It's a small cake. "I had to hide it." <<He>> hugs you again. "Welcome home. I missed you."
+		<<He_ ga>> 당신의 방에 무릎을 꿇더니 당신의 침대 밑에서 무언가를 꺼낸다. 작은 케이크다. "숨길 수밖에 없었어." <<He_ ga>> 다시 당신을 껴안는다. "돌아온 걸 환영해. 보고 싶었어."
 		<br><br>
-		You chat with <<him>> a while. <<He>> asks about where you stayed. What your room was like, if the food was good, if the people were nice. You're not sure how much to tell <<him>>. "I need to go," <<he>> says after a while. "Bailey gave me chores." <<He>> waves goodbye as <<he>> leaves.
+		당신은 <<him_ wa>> 잠시 대화를 나눈다. <<He_ ga>> 당신이 어디에 있었는지 묻는다. 당신의 방은 어땠는지, 음식은 맛있었는지, 사람들은 친절했는지 묻는다. 당신은 <<himPost "에게">> 어디까지 말해야 할지 확신하지 못한다. "난 가봐야겠어," <<he_ ga>> 한참 뒤 말한다. "베일리가 집안일을 시켰거든." <<He_ ga>> 떠나면서 손을 흔든다.
 		<<ltrauma>><<lstress>><<trauma -12>><<stress -12>>
 		<br><br>
 	<</if>>
 <<else>>
-	You enter the orphanage and head to your room. You don't meet anyone.
+	당신은 고아원에 들어가서 당신의 방으로 향한다. 당신은 누구와도 마주치지 못한다.
 	<br><br>
 <</if>>
 
@@ -1870,7 +1870,7 @@ You emerge from the wood far from town, but the road curves north through moor a
 :: Asylum Truth
 
 <<set $outside to 0>><<set $location to "asylum">><<asylumeffects>><<effects>>
-You point at the <<persons>> hiding place. The <<person2>><<person>> crouches beside it and reaches in, pulling the struggling <<person1>><<person>> out by the arm. "Doctor Harper said you need to stay," <<person2>><<he>><<person1>>says as <<he>> drags <<him>> away. "It's for your own good."
+당신은 <<persons_ ga>> 숨은 곳을 가리킨다. <<person2>><<person_ ga>> 그 옆에서 몸을 숙이고 손을 뻗어 몸부림치는 <<person1>><<person_ yi>> 팔을 잡아당긴다. "하퍼 선생님이 당신은 여기에 머물러야 한다고 하셨어요," <<person2>><<he_ ga>><<person1>><<he_ rul>> 끌고 가면서 말한다. "당신을 위한 거예요."
 <br><br>
 <<endevent>>
 <<link [[다음|Asylum]]>><</link>>
@@ -1879,7 +1879,7 @@ You point at the <<persons>> hiding place. The <<person2>><<person>> crouches be
 :: Asylum Lie
 
 <<set $outside to 0>><<set $location to "asylum">><<asylumeffects>><<effects>>
-The <<person2>><<person>> frowns at you, but doesn't push the matter. Once gone, the <<person1>><<person>> emerges and gives you a thankful bow.
+<<person2>><<person_ nun>> 눈살을 찌푸리지만 더 이상 문제 삼지 않고 지나간다. 그러자 <<person1>><<person_ ga>> 나타나 당신에게 고개를 숙여 감사의 인사를 건넨다.
 <br><br>
 <<endevent>>
 <<link [[다음|Asylum]]>><</link>>
@@ -1888,7 +1888,7 @@ The <<person2>><<person>> frowns at you, but doesn't push the matter. Once gone,
 :: Asylum Intervene
 
 <<set $outside to 0>><<set $location to "asylum">><<asylumeffects>><<effects>>
-You pull the <<person1>><<persons>> arm away from the <<person2>><<person>>. They both look shocked. "Don't touch me," the <<person1>><<person>> says. "Just who do you think you are?" The <<person2>><<person>> gives you a grateful smile.
+당신은 <<person1>><<persons_ yi>> 팔을 <<person2>><<personPost "에게서">> 떼어낸다. 둘 다 충격받은 듯하다. "만지지 마," <<person1>><<person_ ga>> 말한다. "네가 뭐라도 되는 줄 알아?" <<person2>><<person_ ga>> 당신에게 감사의 미소를 짓는다.
 <br><br>
 <<endevent>>
 <<link [[다음|Asylum]]>><</link>>
@@ -1897,7 +1897,7 @@ You pull the <<person1>><<persons>> arm away from the <<person2>><<person>>. The
 :: Asylum Flirt
 
 <<set $outside to 0>><<set $location to "asylum">><<asylumeffects>><<effects>>
-You smile back at the <<person>>. <<He>> walks over and you have a pleasant chat.
+당신은 <<personPost "에게">> 미소로 화답한다. <<He_ ga>> 다가와서 당신과 즐거운 대화를 나눈다.
 <<promiscuity1>>
 <<link [[작별 인사를 한다|Asylum]]>><<endevent>><</link>>
 <br>
@@ -1914,15 +1914,15 @@ You smile back at the <<person>>. <<He>> walks over and you have a pleasant chat
 <br><br>
 <<if $seductionskill lt 1000>><span class="gold">당신은 유혹하는 데 좀 더 자신감이 붙었다.</span><</if>><<seductionskilluse>>
 <br><br>
-You lean closer to the <<person>>. "There are a lot of quiet places here," you whisper. "Who knows what one could get up to."
+당신은 <<personPost "에게">> 몸을 더 가까이 기댄다. "여긴 조용한 장소가 많아요," 당신이 속삭인다. "어떤 일이 벌어질지 누가 알까요."
 <<promiscuity2>>
 <<if $seductionrating gte $seductionrequired>>
-	<<He>> glances around, and takes you by the hand. <<He>> leads you to an empty room, then turns and embraces you.
+	<<He_ ga>> 주위를 둘러보더니 당신의 손을 잡는다. <<He_ ga>> 당신을 빈 방으로 이끌더니 돌아서서 당신을 껴안는다.
 	<br><br>
 	<<link [[다음|Asylum Sex]]>><<set $sexstart to 1>><</link>>
 	<br>
 <<else>>
-	"I-It was nice meeting you," <<he>> says. <<He>> walks away.
+	"ㅁ-만나서 반가웠어," <<he_ ga>> 말한다. <<He_ ga>> 떠난다.
 	<br><br>
 	<<endevent>>
 	<<link [[다음|Asylum]]>><</link>>
@@ -1958,21 +1958,21 @@ You lean closer to the <<person>>. "There are a lot of quiet places here," you w
 <<set $outside to 1>><<set $location to "asylum">><<effects>>
 <<if $enemyarousal gte $enemyarousalmax>>
 	<<ejaculation>>
-	"The doctor told me to be more accepting of advances," <<he>> says. "I've been missing out."
+	"의사가 내게 발전을 좀 더 받아들이라고 말했어," <<he_ ga>> 말한다. "그동안 좋은 기회를 놓치고 있었던 셈이지."
 	<br><br>
-	<<He>> kisses your cheek and departs.
+	<<He_ ga>> 당신의 뺨에 키스하고 떠난다.
 	<br><br>
 	<<clotheson>>
 	<<endcombat>>
 <<elseif $enemyhealth lte 0>>
-	You shove the <<person>> away from you and escape into the hallway.
+	당신은 <<person_ rul>> 밀치고 복도로 도망친다.
 	<br><br>
 	<<clotheson>>
 	<<endcombat>>
 <<elseif $finish is 1>>
-	"The doctor told me to be more accepting of advances," <<he>> says. "I've been missing out."
+	"의사가 내게 발전을 좀 더 받아들이라고 말했어," <<he_ ga>> 말한다. "그동안 좋은 기회를 놓치고 있었던 셈이지."
 	<br><br>
-	<<He>> kisses your cheek and departs.
+	<<He_ ga>> 당신의 뺨에 키스하고 떠난다.
 	<br><br>
 	<<clotheson>>
 	<<endcombat>>
@@ -2009,13 +2009,13 @@ You lean closer to the <<person>>. "There are a lot of quiet places here," you w
 <<effects>>
 <<if $enemyarousal gte $enemyarousalmax>>
 	<<ejaculation>>
-	"Don't go whining to no one," the <<person1>><<person>> says. "Not that they'll believe you." The pair laugh as the cell door locks with a click. <<tearful>> you lie back on the bed.
+	"누구에게도 푸념하지 마," <<person1>><<person_ ga>> 말한다. "아무도 믿지 않겠지만." 두 사람이 웃으며 감방 문을 찰칵하고 잠근다. <<tearful>> 당신은 다시 침대에 눕는다.
 	<br><br>
 	<<clotheson>>
 	<<endcombat>>
 	<<link [[다음|Asylum Cell]]>><</link>>
 <<else>>
-	The <<group>> recoil in pain. "Come on," the <<person2>><<person>> says. "There are easier <<girls>> than this." The cell door locks with a click. <<tearful>> you lie back on the bed.
+	<<group_ i>> 고통스러워하며 몸을 움츠린다. "그냥 가자," <<person2>><<person_ ga>> 말한다. "얘 보다 더 쉬운 <<girlsPost "들">> 많아." 감방 문이 찰칵하고 잠긴다. <<tearful>> 당신은 다시 침대에 눕는다.
 	<br><br>
 	<<clotheson>>
 	<<endcombat>>
@@ -2026,33 +2026,33 @@ You lean closer to the <<person>>. "There are a lot of quiet places here," you w
 <<effects>>
 
 <<if $submissive gte 1150>>
-	"O-Okay," you say. "You can show me."
+	"아-알겠어요," 당신이 말한다. "보여주셔도 돼요."
 <<elseif $submissive lte 850>>
-	"Sure," you say. "I'll take a look."
+	"물론이죠," 당신이 말한다. "제가 확인해 드릴게요."
 <<else>>
-	"Okay," you say. "You can show me."
+	"알겠어요," 당신이 말한다. "보여주셔도 돼요."
 <</if>>
 <br><br>
 
-The <<person>> hesitates, then unfolds <<his>> gown, revealing <<his>>
+<<person_ nun>> 망설이다가 <<his_ yi>> 가운을 펼쳐서
 <<if $pronoun is "m">>
 	<<if $NPCList[0].penis isnot "none">>
-		<<print $NPCList[0].penisdesc>>.
+		<<penisdesc_ rul $NPCList[0].penisdesc>> 드러낸다.
 	<<else>>
-		pussy.
+		보지를 드러낸다.
 	<</if>>
 <<else>>
 	<<if $NPCList[0].penis isnot "none">>
-		<<print $NPCList[0].breastsdesc>> and <<print $NPCList[0].penisdesc>>.
+		<<breastsdescPost $NPCList[0].breastsdesc>> 와 <<penisdesc_ rul $NPCList[0].penisdesc>> 드러낸다.
 	<<else>>
-		<<print $NPCList[0].breastsdesc>>.
+		<<breastsdesc_ ul $NPCList[0].breastsdesc>> 드러낸다.
 	<</if>>
 <</if>>
 
-<<He>> shuts <<his>> eyes and stands there, hands clutching <<his>> sides. <<He>> counts under <<his>> breath.
+<<He_ ga>> 눈을 감고 두 손으로 <<his_ yi>> 옆구리를 움켜쥐고 서 있다. <<He_ ga>> 숨을 몰아쉬며 숫자를 센다.
 <br><br>
 
-With a sigh, <<he>> bends over and retrieves <<his>> grown, wrapping it around <<him>> with haste. "Th-thank you," <<he>> says before hurrying away.
+한숨과 함께, <<he_ ga>> 몸을 숙여 <<his_ yi>> 가운을 집어들고 황급히 <<him_ yi>> 몸을 감싼다. "고-고마워," <<he_ ga>> 서둘러 자리를 뜨며 말한다.
 <br><br>
 
 <<endevent>>
@@ -2063,7 +2063,7 @@ With a sigh, <<he>> bends over and retrieves <<his>> grown, wrapping it around <
 :: Asylum Exposure Refuse
 <<effects>>
 
-당신은 고개를 가로젓는다. The <<person>> looks relieved for a moment, but <<his>> ordeal isn't over. <<He>> leaves to find someone else to offer <<himself>> to.
+당신은 고개를 가로젓는다. <<person_ nun>> 잠시 안도하는 듯 보이지만 <<his_ yi>> 시련은 끝나지 않았다. <<He_ ga>> 자신의 몸을 바칠 다른 사람을 찾기 위해 떠난다.
 <br><br>
 
 <<endevent>>
@@ -2074,19 +2074,19 @@ With a sigh, <<he>> bends over and retrieves <<his>> grown, wrapping it around <
 <<effects>>
 
 <<if $submissive gte 1150>>
-	"O-Okay," you say, loud enough for the staff to hear. "You can show me."
+	"아-알겠어요," 당신은 직원들이 들을 만큼 큰 소리로 말한다. "보여주셔도 돼요."
 <<elseif $submissive lte 850>>
-	"Sure," you say, loud enough for the staff to hear. "I'll take a look."
+	"물론이죠," 당신은 직원들이 들을 만큼 큰 소리로 말한다. "제가 확인해 드릴게요."
 <<else>>
-	"Okay," you say, loud enough for the staff to hear. "You can show me."
+	"알겠어요," 당신은 직원들이 들을 만큼 큰 소리로 말한다. "보여주셔도 돼요."
 <</if>>
-You close your eyes.
+당신은 눈을 감는다.
 <br><br>
 
-You hear the shuffle of the <<persons>> gown fall to the floor. <<He>> starts counting under <<his>> breath. <<He>> reaches ten, then you hear another shuffle.
+<<persons_ yi>> 가운이 바닥에 떨어지는 소리가 난다. <<He_ nun>> 숨죽여 숫자를 세기 시작한다. <<He_ ga>> 십까지 세자 또 다른 소음이 들려온다.
 <br><br>
 
-"Thank you!" <<he>> says. You open your eyes. The <<person>> smiles, looking relieved. "Thank you." <<He>> hurries away.
+"고마워!" <<he_ ga>> 말한다. 당신은 눈을 뜬다. <<person_ ga>> 안도한 표정으로 미소 짓는다. "고마워." <<He_ ga>> 서둘러 자리를 뜬다.
 <br><br>
 
 <<endevent>>
@@ -2097,34 +2097,34 @@ You hear the shuffle of the <<persons>> gown fall to the floor. <<He>> starts co
 <<effects>>
 
 <<if $submissive gte 1150>>
-	"O-Okay," you say. "You can show me."
+	"아-알겠어요," 당신이 말한다. "보여주셔도 돼요."
 <<elseif $submissive lte 850>>
-	"Sure," you say. "I'll take a look."
+	"물론이죠," 당신이 말한다. "제가 확인해 드릴게요."
 <<else>>
-	"Okay," you say. "You can show me."
+	"알겠어요" 당신이 말한다. "보여주셔도 돼요."
 <</if>>
-You pretend to close your eyes, though you really keep them a little open. Enough to see.
+당신은 눈을 감은 시늉을 했지만 실제로는 충분히 볼 수 있을 만큼 눈을 약간 뜬다.
 <br><br>
 
-The <<person>> hesitates, then unfolds <<his>> gown, revealing <<his>>
+<<person_ nun>> 망설이다가 <<his_ yi>> 가운을 펼쳐서
 <<if $pronoun is "m">>
 	<<if $NPCList[0].penis isnot "none">>
-		<<print $NPCList[0].penisdesc>>.
+		<<penisdesc_ rul print $NPCList[0].penisdesc>> 드러낸다.
 	<<else>>
-		pussy.
+		보지를 드러낸다.
 	<</if>>
 <<else>>
 	<<if $NPCList[0].penis isnot "none">>
-		<<print $NPCList[0].breastsdesc>> and <<print $NPCList[0].penisdesc>>.
+		<<breastsdescPost $NPCList[0].breastsdesc>> 와 <<penisdesc_ rul $NPCList[0].penisdesc>> 드러낸다.
 	<<else>>
-		<<print $NPCList[0].breastsdesc>>.
+		<<breastsdesc_ ul $NPCList[0].breastsdesc>> 드러낸다.
 	<</if>>
 <</if>>
 
-<<He>> shuts <<his>> eyes and stands there, hands clutching <<his>> sides. <<He>> counts under <<his>> breath.
+<<He_ ga>> 눈을 감고 두 손으로 <<his_ yi>> 옆구리를 움켜쥐고 서 있다. <<He_ ga>> 숨을 몰아쉬며 숫자를 센다.
 <br><br>
 
-With a sigh, <<he>> bends over and retrieves <<his>> grown, wrapping it around <<him>> with haste. "Thank you!" <<he>> says. You pretend to open your eyes. The <<person>> smiles, looking relieved. "Thank you." <<He>> hurries away.
+한숨과 함께, <<he_ ga>> 몸을 숙여 <<his_ yi>> 가운을 집어들고 황급히 <<him_ yi>> 몸을 감싼다. "고마워!" <<he_ ga>> 말한다. 당신은 눈을 뜨는 시늉을 한다. <<person_ ga>> 안도한 표정으로 미소 짓는다. "고마워." <<He_ ga>> 서둘러 자리를 뜬다.
 <br><br>
 
 <<link [[다음|Asylum]]>><<endevent>><</link>>
@@ -2133,7 +2133,7 @@ With a sigh, <<he>> bends over and retrieves <<his>> grown, wrapping it around <
 :: Asylum Garden
 <<effects>>
 
-Each patient is given a bed of soil to work as they please. Many are untended, but some hold small, beautiful displays.
+각각의 환자들에게 자유롭게 가꿀 수 있는 텃밭이 제공되어 있다. 대부분은 관리되지 않은 상태이지만 일부는 작고 근사하게 꾸며져 있다.
 <br><br>
 
 <<plot_effects>>
@@ -2150,8 +2150,8 @@ Each patient is given a bed of soil to work as they please. Many are untended, b
 <<elseif $rng % 4 == 0 and $o_long_and_beautiful gte 1 and $o_long_and_beautiful lte 7>>/*1 in 4 chance if in right stage*/
 	<<if $o_long_and_beautiful lt 9>><<set $o_long_and_beautiful += 1>><</if>>
 	<br>
-	A girl with long, messy, matted hair seems to be watching from a plot nearby.
-	<<if currentSkillValue('tending') gte 600>>She might be impressed by your tending skills. It's hard to tell.<<if $o_long_and_beautiful lt 9>><<set $o_long_and_beautiful += 1>><</if>><</if>>
+	지저분하고 헝클어진 긴 머리를 한 소녀가 근처 밭에서 지켜보고 있는 것 같다.
+	<<if currentSkillValue('tending') gte 600>>그녀는 당신의 관리 스킬에 감명받은 것 같다. 뭐라 딱 잘라 말하긴 힘들다.<<if $o_long_and_beautiful lt 9>><<set $o_long_and_beautiful += 1>><</if>><</if>>
 <</if>>
 <br>
 
@@ -2163,10 +2163,10 @@ Each patient is given a bed of soil to work as they please. Many are untended, b
 :: Asylum Garden Seeds
 <<effects>>
 
-Much of grounds are untended, with wild poppies growing from the exterior fence all the way up to the building. You gather some seeds.
+대부분의 땅은 관리되지 않은 채 야생 양귀비가 외부 울타리에서 건물까지 자라고 있다. 당신은 씨앗을 채집한다.
 <br><br>
 
-<span class="gold">You can now grow <<icon "tending/poppy.png">> poppies.</span>
+<span class="gold">당신은 이제 <<icon "tending/poppy.png">> 양귀비를 재배할 수 있다.</span>
 <br><br>
 
 <<link [[다음|Asylum Garden]]>><</link>>
@@ -2176,9 +2176,9 @@ Much of grounds are untended, with wild poppies growing from the exterior fence 
 :: Asylum Fake Treatment Accept
 <<set $outside to 0>><<set $location to "asylum">><<asylumeffects>><<effects>>
 <<set $phase to 0>>
-You agree to go with them. The pair lead you to a door marked 'staff only,' where more orderlies are waiting.
+당신은 그들과 함께 이동하는 데 동의한다. 두 사람이 당신을 많은 잡역부들이 기다리고 있는 '직원 전용,'이라고 표시된 문으로 데려간다.
 <br>
-They open the door, leading you into a bright but empty cell. A large mirror covers one wall.
+그들이 문을 열고 당신을 밝지만 텅 빈 감방에 넣는다. 한쪽 벽을 커다란 거울이 덮고 있다.
 <br><br>
 <<link [[다음|Asylum Fake Treatment]]>><</link>>
 
@@ -2187,50 +2187,50 @@ They open the door, leading you into a bright but empty cell. A large mirror cov
 :: Asylum Fake Treatment Refuse
 <<set $outside to 0>><<set $location to "asylum">><<asylumeffects>><<effects>>
 <<set $phase to 1>>
-You refuse to go with them, and start to walk away.
+당신은 그들과 함께 가기를 거부하고 자리를 뜨기 시작한다.
 <<if $physiqueSuccess>>
-	The <<person2>><<person>> tries to grab you, <span class="green">but you shove <<him>> away and escape into the midst of a group of patients.</span>
+	<<person2>><<person_ ga>> 당신을 붙잡으려 하지만, <span class="green">당신은 <<him_ rul>> 밀치고 환자들 사이로 도망친다.</span>
 	<br><br>
-	The orderlies don't seem ready to make a scene in front of the other
+	잡역부들은 다른 사람들 앞에서 소란을 피울 준비가 되지 않은 것
 	<<if $asylumstatus gte 20>>
 		<<if $asylumstatus gte 75>>
-			patients, and the other patients gather around you to form a protective shield.<<suspicion 2>> The orderlies
+			같고 다른 환자들이 당신을 중심으로 모여 보호막을 형성한다.<<suspicion 2>> 잡역부들이
 		<<else>>
-			patients. They <<suspicion 1>>
+			같다. 그들은 <<suspicion 1>>
 		<</if>>
-		scowl and walk away.<<gsuspicion>>
+		눈살을 찌푸리며 자리를 뜬다.<<gsuspicion>>
 		<br><br>
 		<<link [[다음|Asylum]]>><</link>>
 	<<else>>
-		patients, but then <span class="red">all the other patients move away from you.</span>
+		하지만, <span class="red">다른 환자들이 모두 당신에게서 멀어진다.</span>
 		<<if $submissive lte 850>>
-			As you try to move with the crowd, another patient trips you and leaves you sprawled on the floor.
+			당신은 군중 속에서 움직이려다 다른 환자가 발을 걸어 당신을 바닥에 나뒹굴게 된다.
 		<</if>>
-		The <<person2>><<person>> and the <<person1>><<person>> grab you and together lead you to a door marked 'staff only'
-		where more orderlies wait.
+		<<person2>><<person_ wa>> <<person1>><<person_ ga>> 당신을 붙잡고 많은 잡역부들이 기다리고 있는 '직원 전용' 이라고 적힌
+		문으로 데려간다.
 		<br>
-		They open the door, leading you into a bright but empty cell. A large mirror covers one wall.
+		그들이 문을 열고 당신을 밝지만 텅 빈 감방에 넣는다. 한쪽 벽을 커다란 거울이 덮고 있다.
 		<br><br>
 		<<link [[다음|Asylum Fake Treatment]]>><</link>>
 	<</if>>
 	<br>
 <<elseif $asylumstatus gte 75>>
-	<span class="red">The <<person2>><<person>> grabs you and tackles you to the floor.</span>
-	The <<person>> is grappling you into an armlock, when, <span class="green">with a yell, <<he>> is lifted into the air and hurled across the room.</span>
-	You see the <<person1>><<person>> also backing away as a number of patients gather around you.
+	<span class="red"><<person2>><<person_ ga>> 당신을 붙잡고 바닥에 패대기친다.</span>
+	<<person_ ga>> 당신의 팔을 붙잡고 씨름하고 있을 때, <span class="green">비명과 함께 <<he_ ga>> 공중으로 들어올려져 방안으로 내던져진다.</span>
+	당신 주위에 많은 환자가 모이면서 <<person1>><<person_ ga>> 뒷걸음질 친다.
 	<br>
-	After a moment, the <<person>> scowls at you and walks away. <<suspicion 2>><<gsuspicion>>
+	잠시 후, <<person_ nun>> 눈살을 찌푸리며 자리를 뜬다. <<suspicion 2>><<gsuspicion>>
 	<br><br>
-	The other patients nod, smile and pat your on the shoulder as they go back to what they were doing.
+	다른 환자들이 고개를 끄덕이고 미소를 지으며 당신의 어깨를 토닥인 후 하던 일로 되돌아간다.
 	<br><br>
 	<<link [[다음|Asylum]]>><</link>>
 	<br>
 <<else>>
-	<span class="red">The <<person2>><<person>> grabs you and tackles you to the floor.</span>
-	Before you can recover <<he>> has you painfully armlocked, and together they lead you to a door marked 'staff only'
-	where more orderlies are waiting.<<gpain>><<pain 2>>
+	<span class="red"><<person2>><<person_ ga>> 당신을 붙잡고 바닥에 패대기친다.</span>
+	당신이 몸을 추스르기도 전에 <<he_ ga>> 당신의 팔을 고통스럽게 결박하고는, 함께 많은 잡역부들이 기다리고 있는 '직원 전용'이라고 적힌
+	문으로 데려간다.<<gpain>><<pain 2>>
 	<br>
-	They open the door, leading you into a bright but empty cell. A large mirror covers one wall.
+	그들이 문을 열고 당신을 밝지만 텅 빈 감방에 넣는다. 한쪽 벽을 커다란 거울이 덮고 있다.
 	<br><br>
 	<<link [[다음|Asylum Fake Treatment]]>><</link>>
 	<br>
@@ -2240,18 +2240,18 @@ You refuse to go with them, and start to walk away.
 
 :: Asylum Fake Treatment
 <<set $outside to 0>><<set $location to "asylum">><<asylumeffects>><<effects>>
-"Doctor Harper's behind that one-way mirror," the <<person1>><<person>> says, pointing at the mirror.
-"Observing and taking complete notes of everything that happens here. Doctor Harper stressed that this
-is an important part of your assessment so you need to be on your best behaviour.
-<<if $phase is 1>>Especially after the way you behaved just now.<</if>> Understood?"
+"하퍼 선생님이 저 일방향 거울 뒤에 있어," <<person1>><<person_ ga>> 거울을 가리키며 말한다.
+"여기서 일어나는 모든 일을 관찰하고 완벽하게 기록하고 있어. 하퍼 선생님은 이게
+네 평가의 중요한 부분이니 최선을 다해 행동해야 한다고 강조했어.
+<<if $phase is 1>>특히 아까 네가 행동한 것처럼 말이야.<</if>> 알았어?"
 <br>
 
 <<if $submissive gte 1150>>
-	"Yes, <<sir>>," you say. "I understand."
+	"네, <<sirPost>>," 당신이 말한다. "이해했어요."
 <<elseif $submissive lte 850>>
-	You glare at them, saying nothing.
+	당신은 아무 말도 하지 않고 그들을 노려본다.
 <<else>>
-	You nod.
+	당신은 고개를 끄덕인다.
 <</if>>
 <br><br>
 <<set $ft_count to 5>>
@@ -2259,94 +2259,94 @@ is an important part of your assessment so you need to be on your best behaviour
 	<<set $ft_event to "milk">><<person2>>
 	<<if $worn.upper.name isnot "straightjacket">>
 		<<bind>><<upperwear 35>>
-		The <<person>> puts a medical straightjacket on you, binding your arms.
+		<<person_ ga>> 당신에게 의료용 구속복을 입히고 팔을 묶는다.
 	<</if>>
 	<br><br>
-	You are led to the wall opposite the mirror - you notice a number of steel chain-links embedded in the wall at different heights.
-	The <<person1>><<person>> turns you around so you are facing into the room. A large number of orderlies have gathered near the door.
-	The <<person>> pushes you back against the wall, while the <<person2>><<person>> clips the back of your straightjacket to the links on the wall
-	- once at the waist and once at the neck - locking you standing in place. The <<person>> unfastens something at the side of your straightjacket,
-	and the <<person1>><<person>> pulls at the front. A section comes away, leaving your arms bound but your
+	거울 맞은편 벽으로 이동하자 벽에 수많은 쇠사슬 고리가 다양한 높이로 박혀 있는 것을 발견한다.
+	<<person1>><<person_ ga>> 당신을 돌려서 방을 바라보게 한다. 수많은 잡역부들이 문 근처에 모인다.
+	<<person_ ga>> 당신을 벽에 밀착시키는 동안 <<person2>><<person_ nun>> 당신의 구속복 뒷면을 벽의 고리에 걸고
+	- 허리에 한 번 그리고 목에 한 번 - 당신을 제자리에 고정시킨다. <<person_ ga>> 당신의 구속복 옆쪽의 무언가를 풀더니,
+	<<person1>><<person_ ga>> 앞에서 잡아당긴다. 일부가 떨어져 나가면서 당신의 팔은 묶여 있지만 당신의
 	<<if !$worn.under_upper.type.includes("naked")>>
-		<<undertop>> exposed. The <<person>> grabs your $worn.under_upper.name and pulls it up, fully exposing your <<breasts>>.
+		<<undertop_ ga>> 노출된다. <<person_ ga>> 당신의 <<worn_under_upper_name_ rul>> 잡고 위로 당겨서 당신의 <<breasts_ rul>> 완전히 노출시킨다.
 	<<else>>
-		<<breasts>> fully exposed.
+		<<breasts_ i>> 완전히 노출된다.
 	<</if>>
-	<<He>> gives one of your breasts a squeeze and a jet of milk squirts out.
+	<<He_ ga>> 당신의 유방 한 쪽을 꽉 쥐자 모유가 뿜어져 나온다.
 	<br><br>
-	"A number of our patients suffer from eating disorders," the <<person>> says. "As part of their treatment, and yours,
-	in a few moments, they will be led into this room and will drink from you. Doctor Harper says it's very important for you to relax
-	and think about how you are helping to nourish and sustain others. This hood will hide your face to protect your dignity."
+	"많은 환자들이 섭식 장애를 앓고 있어," <<person_ ga>> 말한다. "그들의 치료의 일환이자 네 치료의 일환으로,
+	잠시 동안 환자들을 데려와서 네게서 모유을 마시게 할 거야. 하퍼 선생님은 네가 긴장을 풀고
+	다른 사람들에게 영양을 공급하고 삶을 유지하는 데 얼마나 도움을 주고 있는지 생각하게 매우 중요하다고 말했어. 이 두건이 네 얼굴을 가려서 네 존엄성을 지켜줄 거야."
 	<br><br>
-	The hood is placed over your head, plunging you into darkness.
+	머리 위로 두건이 씌워지면서 당신을 어둠 속에 빠뜨린다.
 	<br>
-	Almost immediately, lips clamp around your <<nipples>>.
+	거의 즉각적으로 입술이 당신의 <<nipples_ rul>> 문다.
 	<br><br>
 	<<link [[다음|Asylum Fake Treatment Milked]]>><<set $ft_count to 8>><</link>>
 <<elseif $rng gte 33 and !playerChastity()>>
 	<<set $ft_event to "masturbation">>
-	The <<person2>><<person>>
+	<<person2>><<person_ ga>>
 	<<if $worn.upper.name isnot "straightjacket">>
 		<<bind>><<upperwear 35>>
-		puts a medical straightjacket on you that binds your arms,
+		당신에게 팔을 묶는 의료용 구속복을 입히고
 	<<else>>
-		checks your straightjacket,
+		당신의 구속복을 확인하고
 	<</if>>
 	<<if $worn.under_lower.type.includes("naked") and $worn.genitals.type.includes("naked")>>
-		and
+		나서
 	<<else>>
 		<<if !$worn.under_lower.type.includes("naked")>>
 			<<set _undies to $worn.under_lower.name>>
 		<<elseif !$worn.genitals.type.includes("naked")>>
 			<<set _undies to $worn.genitals.name>>
 		<</if>>
-		<<underlowerstrip>>removes your _undies, and
+		<<underlowerstrip>>당신의 _undies를 벗긴 뒤
 	<</if>>
-	leads you in front of the mirror. A chair is placed behind you.
+	당신을 거울 앞으로 데려간다. 당신 뒤에 의자가 놓여 있다.
 	<br>
-	"Have a seat," the <<person1>><<person>> says as hands pull you down. The <<person2>><<person>> attaches your straightjacket to the chair
-	as the <<person1>><<person>> ties your calves and ankles to the chair legs, forcing your knees apart.
+	"앉아," the <<person1>><<person_ ga>> 당신을 아래로 끌어내리며 말한다. <<person2>><<person_ ga>> 당신의 구속복을 의자에 부착하고
+	<<person1>><<person_ ga>> 당신의 종아리와 발목을 의자 다리에 묶어 당신의 무릎을 강제로 벌린다.
 	<br><br>
 	<<generate3>><<generate4>><<generate5>>
 	<<if $o_long_and_beautiful gte 1 and $o_long_and_beautiful lte 7>><<set $o_long_and_beautiful += 1>> /*Modifies person 4 enough */
 		<<set $NPCList[3].description to "long-haired">><<set $NPCList[3].adult to 0>><<set $NPCList[3].gender = "f">><<set $NPCList[3].pronoun = "f">>
 	<</if>>
 
-	A moment later a <<person4>><<person>> is led in and set up similarly beside you. Finally,
-	a <<person5>><<person>> is set up similarly beside <<person4>><<him>>.
+	잠시 후 <<person4>><<person_ ga>> 안으로 들어와서 당신 옆에 비슷한 자세로 배치된다. 마침내
+	<<person5>><<personPost "도">> <<person4>><<him_ yi>> 옆에 비슷한 자세로 배치된다.
 	<br><br>
-	<<person1>>"This is a trust exercise. Despite your obvious vulnerability, you need to learn that the world doesn't want to hurt you.
-	Mostly it just wants to make you feel good. All of you believe you are victims. Instead you need to learn to accept approaches as... opportunities."
+	<<person1>>"이건 신뢰를 쌓는 훈련이야. 넌 명백하게 취약하지만 세상은 너를 해치려 하지 않는다는 사실을 배워야 한다.
+	대부분 그저 널 기분 좋게 해주고 싶을 뿐이야. 너희 모두가 스스로를 피해자라고 믿고 있지. 그 대신 접근을... 기회로 받아들이는 법을 배워야 해."
 	<br>
-	The <<person4>><<person>> next to you struggles against <<his>> bindings.
+	옆에 있는 <<person4>><<person_ ga>> <<his_ yi>> 구속에 맞서 고군분투하고 있다.
 	<br>
 
-	A <<person3>><<person>> walks behind the chair-bound <<person5>><<person>>. The <<person2>><<person>> moves behind the chair-bound
-	<<person4>><<person>> next to you. Finally the <<person1>><<person>> moves behind you.
+	<<person3>><<person_ ga>> 의자에 묶인 <<person5>><<person_ yi>> 뒤로 이동한다. <<person2>><<person_ ga>> 당신 옆에 있는 의자에 묶인
+	<<person4>><<person_ yi>> 뒤로 이동한다. 마지막으로 <<person1>><<person_ ga>> 당신 뒤로 이동한다.
 	<br><br>
-	"Begin."
+	"시작해."
 	<br><br>
 	<<link [[다음|Asylum Fake Treatment Masturbation]]>><<set $ft_count to 20>><<set $ft_five to random(11,15)>><<set $ft_four to random(5,10)>><</link>>
 <<else>>
 	<<set $ft_event to "bukkake">>
 	<<if $worn.upper.name isnot "straightjacket">>
 		<<bind>><<upperwear 35>>
-		The <<person>> puts a medical straightjacket on you, binding your arms.
+		<<person_ ga>> 당신에게 의료용 구속복을 입히고 팔을 묶는다.
 	<</if>>
-	You are led to the wall opposite the mirror - you notice a number of steel chain-links embedded in the wall at different heights.
-	The <<person>> turns you around so you are facing into the room. A large number of orderlies have gathered near the door.
-	The <<person>> pushes you down to a kneeling position, backed against the wall, while the <<person2>><<person>> clips the back of your straightjacket
-	to the links on the wall and binds your feet, fixing you in place.
+	거울 맞은편 벽으로 이동하자 벽에 수많은 쇠사슬 고리가 다양한 높이로 박혀 있는 것을 발견한다.
+	<<person_ ga>> 당신을 돌려서 방을 바라보게 한다. 수많은 잡역부들이 문 근처에 모인다.
+	<<person_ ga>> 당신을 무릎 꿇린 채 벽에 밀착시키는 동안, <<person2>><<person_ nun>> 당신의 구속복 뒷면을
+	벽의 고리에 걸고 당신의 발을 묶어 제자리에 고정시킨다.
 	<br><br>
-	"The doctors believe an irrational phobia of sexual fluids is driving your condition," the <<person1>><<person>> tells you.
-	"Our staff have kindly agreed to help with an exposure therapy approach."
+	"의사선생님은 성적 체액에 대한 비이성적인 공포증이 네 상태를 악화시킨다고 믿고 있어," <<person1>><<person_ ga>> 당신에게 말한다.
+	"우리 직원들은 친절하게도 노출 치료 접근법을 돕기로 동의했어."
 	<br>
 	<<if $malechance gte 1 and $cbchance lt 100 or $malechance lt 100 and $dgchance gte 1>>
-		Glancing back you see a number of the orderlies already have their dicks out.
+		뒤를 돌아보니 이미 많은 잡역부들이 자지를 꺼내고 있는 것이 보인다.
 	<</if>>
 	<br><br>
-	The <<person>> <<if $NPCList[0].penis isnot "none">>unzips and pulls out <<his>> erect cock,<<else>>pulls down <<his>> orderly uniform, exposing <<his>> already wet pussy,<</if>>
-	"Let's begin."
+	<<person_ ga>> <<if $NPCList[0].penis isnot "none">>지퍼를 내리고 <<his_ yi>> 발기한 자지를 꺼낸다,<<else>><<his_ yi>> 잡역부 유니폼을 끌어내려 <<his_ yi>> 벌써 젖어있는 보지를 드러낸다,<</if>>
+	"시작하자."
 	<br><br>
 	<<link [[다음|Asylum Fake Treatment Bukkake]]>><</link>>
 <</if>>
@@ -2355,10 +2355,10 @@ is an important part of your assessment so you need to be on your best behaviour
 :: Asylum Fake Treatment Milked
 <<set $outside to 0>><<set $location to "asylum">><<asylumeffects>><<effects>>
 <<pass 5>>
-<<set _they_drink to either("Anonymous mouths continue to hungrily suck milk from you.","Hungry mouths lap at your nipples.","Mouths suck and massage milk from your teats.","Mouths clamp to your breasts as unseen people drink from you.","They suck milk from you insatiably.")>>
+<<set _they_drink to either("익명의 입이 당신의 모유를 게걸스럽게 빨아댄다.","굶주린 입이 당신의 유두를 덥석 문다.","입이 당신의 유두에서 모유를 빨고 마사지한다.","입이 당신의 유방에 달라붙고 보이지 않는 누군가가 당신의 모유를 마신다.","그들이 끊임없이 당신의 모유를 빨아들인다.")>>
 <<if $ft_count is 8>>
-	They drink thirstily from your breasts. After a time, the mouth on the <<print either("left","right")>> finishes and leaves.
-	Another mouth quickly replaces them. A minute or so later, this happens on the other side.
+	그들은 당신의 유방에서 목을 축인다. 잠시후, <<print either("왼쪽","오른쪽")>> 입이 다 마신후 떠난다.
+	다른 입이 재빨리 자리를 차지한다. 1분 정도 지나자 반대편에서도 같은 일이 벌어진다.
 	<<garousal>><<arousal 200 "breasts">>
 	<<if $arousal gte $arousalmax>>
 		<<orgasm>>
@@ -2372,46 +2372,46 @@ is an important part of your assessment so you need to be on your best behaviour
 		<<set _rand to random(1,10)>>
 		<br>
 		<<if _rand is 1>>
-			An anonymous hand <<print either("gently","roughly","rhythmically","persistently","sensuously")>> <<print either("fondles","rubs","teases")>> your <<genitals>>.
+			익명의 손이 당신의 <<genitals_ rul>> <<print either("부드럽게","거칠게","리드미컬하게","고집스럽게","감각적으로")>> <<print either("애무한다","문지른다","애태운다")>>.
 			<<garousal>><<arousal 200 "genitals">>
 		<<elseif _rand is 2>>
-			One of them bites your <<nipple>>.
+			그들 중 한명이 당신의 <<nipple_ rul>> 문다.
 			<<ggpain>><<pain 8>>
 		<<elseif _rand is 3>>
-			A tongue playfully circles and teases your <<nipple>> between sucks.
+			혀가 당신의 <<nipple_ rul>> 빨면서 장난스럽게 원을 그리며 애태운다.
 			<<ggarousal>><<arousal 400 "breasts">>
 		<<elseif _rand is 4>>
-			Someone flicks your <<nipple>>.
+			누군가 당신의 <<nipple_ rul>> 튕긴다.
 			<<gpain>><<pain 3>>
 		<<elseif _rand is 5>>
-			The people to your left and right seem to be working together as their mouths suck and squeeze your <<nipples>> in perfect rhythm.
+			당신의 좌우에 있는 사람들이 완벽한 리듬으로 당신의 <<nipples_ rul>> 입으로 빨고 쥐어짜면서 함께 움직인다.
 			<<ggarousal>><<arousal 400 "breasts">>
 		<<elseif _rand is 6>>
-			One mouth barely drinks, preferring to blow and then lick at your <<nipple>>.
+			한 입은 거의 마시지 않고, 당신의 <<nipple_ rul>> 불고 핥기에 집중한다.
 			<<ggarousal>><<arousal 500 "breasts">>
 		<<elseif _rand is 7>>
-			A hand painfully slaps your breast.
+			손이 당신의 가슴을 고통스럽게 때린다.
 			<<ggpain>><<pain 8>>
 			<br>
-			"Hey! Take it easy," a voice says.
+			"이봐! 진정해," 한 목소리가 말한다.
 			<br>
-			"Sorry."
+			"미안."
 			<br>
 		<<elseif _rand is 8>>
 			<<set _random_milk to random(50, 100)>>
-			As one sucks, they squeeze your <<breasts>> with their hands to force out more milk.<<milk_amount `-_random_milk`>>
+			한 명이 빠는 동안 손으로 당신의 <<breasts_ rul>> 쥐어짜서 더 많은 모유가 나오게 한다.<<milk_amount `-_random_milk`>>
 		<</if>>
 		<br>
 		<<if $arousal gte $arousalmax>>
 			<<orgasm>>
-			Mouths clamp to your <<nipples>>, sucking hard as you cum.
+			당신의 <<nipplesPost "에">> 입을 고정하고 당신이 사정할 때 힘껏 빨아댄다.
 		<</if>>
 		<br>
 		<<set _random_milk to random(200,300)>>
 		<<link [[다음|Asylum Fake Treatment Milked]]>><<milk_amount `-_random_milk`>><<set $ft_count -= 1>><</link>>
 	<<elseif $milk_amount gte 50>>
-		As yet another greedy mouth tries to <<print either("suck","suck and squeeze")>> the milk from your breasts
-		you start to run dry. Soon you are getting close to dry on both sides. Hands and mouths work harder to squeeze and suck milk from you.
+		아직 욕심이 많은 또 다른 입이 당신의 유방을 <<print either("빨려고","빨고 쥐어짜려고")>> 하지만
+		당신의 모유가 마르기 시작한다. 곧 양쪽 모유가 거의 다 마르기 시작한다. 손과 입이 더 힘차게 모유를 짜내고 빨아댄다.
 		<<ggarousal>><<arousal 400 "breasts">><<gpain>><<pain 3>>
 		<br>
 		<<if $arousal gte $arousalmax>>
@@ -2421,8 +2421,8 @@ is an important part of your assessment so you need to be on your best behaviour
 		<<set _random_milk to random(200,300)>>
 		<<link [[다음|Asylum Fake Treatment Milked]]>><<milk_amount `-_random_milk`>><<set $ft_count -= 1>><</link>>
 	<<else>>
-		Even though you are nearly dry, thirsty mouths insistently <<print either("suck at","pull at","try to suck milk from")>> your <<breasts>>.
-		Your nipples feel sore and tender as they suck the last of the milk from you.
+		거의 마르다시피 했는데도 목마른 입이 집요하게 당신의 <<breasts_ rul>> <<print either("빨아댄다","잡아당긴다","빨려고 애쓴다")>>.
+		그들이 마지막 남은 모유를 빨아들이자 당신의 유두가 아프고 따끔거린다.
 		<<ggarousal>><<arousal 500 "breasts">><<gpain>><<pain 8>>
 		<br>
 		<<if $arousal gte $arousalmax>>
@@ -2432,30 +2432,30 @@ is an important part of your assessment so you need to be on your best behaviour
 		<<link [[다음|Asylum Fake Treatment Milked]]>><<set $milk_amount to 0>><<set $ft_count to 0>><</link>>
 	<</if>>
 <<else>>
-	<<if $milk_amount gt 0>>Finally one mouth leaves and none replace it. The mouth on the other side drinks for another minute or so, before also leaving.
+	<<if $milk_amount gt 0>>마침내 한 입이 떠나고 다른 입이 그 자리를 차지한다. 반대쪽 입이 1분 정도 더 마신 다음 역시 자리를 떠난다.
 		<<ggarousal>><<arousal 400 "breasts">>
 	<<else>>
-		No more come to you.
+		아무도 당신에게 오지 않는다.
 	<</if>>
 	<br>
 	<<if $arousal gte $arousalmax>>
 		<<orgasm>>
 	<<elseif $arousal gte ($arousalmax / 5) * 4>>
-		Your bare nipples tingle in the air.
+		허공에 노출된 젖꼭지가 따끔거린다.
 		<br>
 		<<if $submissive gte 1150>>
-			"More," you whimper. "Please, more."
+			"조금만 더," 당신이 속삭인다. "제발, 조금만 더."
 			<br>
 		<</if>>
 	<</if>>
-	Your breasts feel a lot lighter. <<llstress>><<stress 18>>
+	가슴이 훨씬 가벼워진 느낌이다. <<llstress>><<stress 18>>
 	<br><br>
-	"Uhm... okay," the <<person>> says loudly. "Get these patients out."
+	"음... 좋아," <<person_ ga>> 큰 소리로 말한다. "환자들 내보내."
 	<br>
-	The door opens and <<if currentSkillValue('science') gte 600 or currentSkillValue('skulduggery') gte 600>>closes suspiciously quickly.<<else>>closes.<</if>>
+	문이 열리고 <<if currentSkillValue('science') gte 600 or currentSkillValue('skulduggery') gte 600>>의심스러울 정도로 빠르게 닫힌다.<<else>>닫힌다.<</if>>
 	<br><br>
-	The hood lifts off your head and the straightjacket is closed to cover your <<breasts>>.
-	As the <<person2>><<person>> releases you from the wall, the <<person1>><<person>> talks to you.
+	두건이 벗겨지고 구속복이 아래로 내려오면서 당신의 <<breasts_ rul>> 가린다.
+	<<person2>><<person_ ga>> 벽에서 당신을 풀어주자 <<person1>><<person_ ga>> 당신에게 말한다.
 	<br><br><br>
 	<<link [[다음|Asylum Fake Treatment Finish]]>><<unset $ft_count>><</link>>
 <</if>>
@@ -2464,28 +2464,28 @@ is an important part of your assessment so you need to be on your best behaviour
 :: Asylum Fake Treatment Masturbation
 <<set $outside to 0>><<set $location to "asylum">><<asylumeffects>><<effects>>
 <<pass 5>>
-<<set _respond to either("grunt","gasp","groan","inhale sharply","pant","moan")>>
-<<set _ly to either("busily","energetically","frantically","resolutely","fanatically","quickly","furiously","relentlessly")>>
-<<set _ly2 to either("busily","energetically","frantically","resolutely","fanatically","quickly","furiously","relentlessly")>>
-<<set _stimulates_him to either("milks <<his>> cock","rubs <<his>> cock","fondles <<his>> cock","plays with <<his>> dick","milks <<his>> dick")>>
-<<set _stimulates_her to either("fingers <<his>> pussy","rubs <<his>> quim","fondles <<his>> quim","fingers <<his>> cunt","fingers <<his>> quim")>>
-<<set _is_done to either("whimpers gently.","continues to pant.","is still breathing heavily.","sofly whimpers.")>>
-<<if $ft_count lte ($ft_four - 2)>><<set _crowd = "Some orderlies are still watching. Others are openly exchanging money. A few have left.">>
-<<elseif $ft_count lt $ft_four>><<set _crowd="Some orderlies are cheering. They are again exchanging money. Do they gamble on this?">>
-<<elseif $ft_count is $ft_four>><<set _crowd="A number of orderlies shout at the <<person4>><<person>> in disbelief. Others cheer.">>
-<<elseif $ft_count lt ($ft_five - 2)>><<set _crowd="Some of the orderlies shout encouragement to you. Others shout to the <<person4>><<person>>.">>
-<<elseif $ft_count lt $ft_five>><<set _crowd="Some orderlies seem disappointed, others seems amused. You think you see money exchanging hands.">>
-<<elseif $ft_count is $ft_five>><<set _crowd="Several orderlies groan or shout in disappointment. More cheer and laugh.">>
-<<elseif $ft_count gt 18>><<set _crowd="The crowd of orderlies shout encouragement at you, the <<person4>><<person>> and the <<person5>><<person>>.<br>'Hang in there!'<br>'You can do it.'<br>">>
+<<set _respond to either("끙끙거리는","숨을 삼키는","탄식하는","날카롭게 들이쉬는","헐떡이는","신음하는")>>
+<<set _ly to either("바쁘게","열정적으로","미친 듯이","단호하게","광적으로","빠르게","격렬하게","가차없이")>>
+<<set _ly2 to either("바쁘게","열정적으로","미친 듯이","단호하게","광적으로","빠르게","격렬하게","가차없이")>>
+<<set _stimulates_him to either("<<his_ yi>> 자지를 착유하자","<<his_ yi>> 자지를 문지르자","<his_ yi>> 자지를 애무하자","<his_ yi>> 좆을 만지작 거리자","<his_ yi>> 좆을 착유하자")>>
+<<set _stimulates_her to either("<<his_ yi>> 보지에 손가락을 넣자","<<his_ yi>> 질을 문지르자","<<his_ yi>> 질을 애무하자","<<his_ yi>> 성기에 손가락을 넣자","<<his_ yi>> 질에 손가락을 넣자")>>
+<<set _is_done to either("부드럽게 훌쩍거린다.","계속 숨을 헐떡인다.","여전히 숨을 가쁘게 쉬고 있다.","조용히 훌쩍거린다.")>>
+<<if $ft_count lte ($ft_four - 2)>><<set _crowd = "몇몇 잡역부들이 여전히 지켜보고 있다. 다른 이들은 대놓고 돈을 교환하고 있다. 몇 명은 떠났다.">>
+<<elseif $ft_count lt $ft_four>><<set _crowd="일부 잡역부들이 환호하고 있다. 그들은 다시 돈을 교환한다. 그들은 이걸로 도박을 하는 걸까?">>
+<<elseif $ft_count is $ft_four>><<set _crowd="몇몇 잡역부들이 불신에 가득 차 <<person4>><<personPost "에게">> 소리를 지른다. 다른 이들은 환호한다.">>
+<<elseif $ft_count lt ($ft_five - 2)>><<set _crowd="잡역부들 중 일부가 당신에게 격려의 함성을 지른다. 다른 사람들은 <<person4>><<person_ rul>> 향해 함성을 지른다.">>
+<<elseif $ft_count lt $ft_five>><<set _crowd="몇몇 잡역부들은 실망한 기색이 역력하고, 몇몇은 즐거워 보인다. 당신은 돈을 주고받는 것을 본 것 같다.">>
+<<elseif $ft_count is $ft_five>><<set _crowd="몇몇 잡역부들이 실망한 듯 탄식하거나 소리를 지른다. 더 많은 환호와 웃음이 쏟아진다.">>
+<<elseif $ft_count gt 18>><<set _crowd="잡역부들이 당신과 <<person4>><<personPost>>, 그리고 <<person5>><<personPost "에게">> 격려의 함성을 지른다.<br>'좀만 더 참아!'<br>'넌 할 수 있어.'<br>">>
 <<elseif $ft_count is 0>>
-	There is an air of disappointment as the <<person1>><<person>> leaves you.
-<<elseif $ft_count%2>><<set _crowd = either("The crowd of orderlies watch.","The crowd jostle to get a better view.","The crowd shouts encouragement.")>>
+	<<person1>><<person_ ga>> 당신을 떠나자 아쉬워하는 분위기가 감돈다.
+<<elseif $ft_count%2>><<set _crowd = either("잡역부들이 지켜보고 있다.","관중들이 더 잘 보기 위해 서로 뒤엉켜 있다.","관중들이 격려의 함성을 지른다.")>>
 <<else>><<set _crowd = "">>
 <</if>>
 <br>
 
 <<if $ft_count is 20>>
-	The <<person1>><<person>> grabs you, one hand rubbing your chest, the other reaching for your <<genitals>>. <<arousal 100 "breasts">><<arousal 100 "genitals">>
+	<<person1>><<person_ ga>> 당신을 붙잡고 한 손은 당신의 가슴을 문지르고 다른 한 손은 당신의 <<genitalsPost "에">> 손을 뻗는다. <<arousal 100 "breasts">><<arousal 100 "genitals">>
 	<<if $arousal gte $arousalmax>>
 		<<orgasm>>
 		<<set $ft_count to -10>>
@@ -2493,28 +2493,28 @@ is an important part of your assessment so you need to be on your best behaviour
 	<br>
 	_crowd
 	<br><br>
-	<<link [[Let yourself enjoy it|Asylum Fake Treatment Masturbation]]>><<arousal 200>><<set $ft_count -=1>><</link>><<garousal>>
+	<<link [[마음껏 즐긴다|Asylum Fake Treatment Masturbation]]>><<arousal 200>><<set $ft_count -=1>><</link>><<garousal>>
 	<br>
 	<<link [[저항한다|Asylum Fake Treatment Masturbation]]>><<arousal -100>><<set $ft_count -=1>><</link>>
 	<br>
 <<elseif $ft_count gte 1>>
 	<<if $ft_count is 19>>
-		The <<person1>><<person>> slips a hand under the straightjacket to tease your <<nipple>>, while the other grabs your <<genitals>>. <<arousal 200 "breasts">><<arousal 100 "genitals">>
+		<<person1>><<person_ ga>> 한 손을 구속복 아래로 미끄러뜨려 당신의 <<nipple_ rul>> 희롱하고, 다른 한 손으로 당신의 <<genitals_ rul>> 잡는다. <<arousal 200 "breasts">><<arousal 100 "genitals">>
 	<<elseif $ft_count gt $ft_five>>
 		<<if $rng>>
-			You hear the <<person4>><<person>> _respond as the <<person2>><<person>>
+			당신은 <<person4>><<person>> _respond as the <<person2>><<person>>
 			<<person4>><<if $NPCList[0].penis isnot "none">>_stimulates_him.<<else>>_stimulates_her.<</if>>
 		<<else>>
 			You hear the <<person5>><<person>> _respond as the <<person3>><<person>>
 			<<person5>><<if $NPCList[0].penis isnot "none">>_stimulates_him.<<else>>_stimulates_her.<</if>>
 		<</if>>
-		The <<person1>><<persons>> hands continue to work your <<genitals>> and your <<breasts>>.<<arousal 200 "breasts">><<arousal 200 "genitals">>
+		<<person1>><<persons_ yi>> 손이 계속해서 당신의 <<genitals_ wa>> <<breasts_ ul>> 계속해서 자극한다.<<arousal 200 "breasts">><<arousal 200 "genitals">>
 	<<elseif $ft_count is $ft_five>>
-		You hear the <<person5>><<person>> moan loudly, and <<if $NPCList[0].penis isnot "none">>see a spurt of cum fly toward the mirror and<<else>>see squirts of female ejaculate<</if>> splatter on the floor.
+		<<person5>><<person_ ga>> 큰 소리로 신음을 내는 소리가 들리더니 <<if $NPCList[0].penis isnot "none">>정액이 거울을 향해 날아가<<else>>여성의 사정액이 거울을 향해 날아가<</if>> 바닥에 흩뿌려진다.
 		<br>
-		Some of the orderlies cheer. You see them excitedly passing money between each other.
+		일부 잡역부들이 환호한다. 그들이 신나게 서로 돈을 주고받는다.
 		<br>
-		The <<person2>><<person>> moves both hands to focus on your <<genitals>> and continues with renewed intensity. <<arousal 600 "genitals">>
+		<<person2>><<person_ ga>> 양손으로 당신의 <<genitalsPost "에">> 초점을 맞추고 새로운 격렬함으로 이어간다.<<arousal 600 "genitals">>
 	<<elseif $ft_count gt $ft_four>>
 		<<if $rng>>
 			You hear the <<person4>><<person>> _respond as the <<person2>><<person>>
@@ -2522,16 +2522,16 @@ is an important part of your assessment so you need to be on your best behaviour
 		<</if>>
 		The <<person1>><<persons>> hands continue to _ly2 work your <<genitals>>. <<arousal 600 "genitals">>
 	<<elseif $ft_count is $ft_four>>
-		The <<person4>><<person>> beside you starts to shudder as, silently, <<he>> cums
-		<<if $NPCList[0].penis isnot "none">>sending a large spurt of cum toward the mirror
-		<<else>>squirting hard
-		<</if>>and making a mess of the floor in front of <<him>>.
+		옆에 있던 <<person4>><<person_ ga>> 몸을 부르르 떨기 시작하더니, <<he_ ga>>
+		<<if $NPCList[0].penis isnot "none">>조용히 거울을 향해 커다란 정액 덩어리를 내뿜으며
+		<<else>>힘차게 내뿜으며
+		<</if>><<him_ yi>> 앞쪽 바닥을 난장판으로 만든다.
 		<br>
-		More orderlies cheer. You see them excitedly passing money between each other.
+		더 많은 잡역부들이 환호한다. 그들이 신나게 서로 돈을 주고받는다.
 		<br>
-		With a sigh, the <<person1>><<person>> eases up on your <<genitals>>. <<arousal 300 "genitals">>
+		한숨과 함께, <<person1>><<person_ ga>> 당신의 <<genitalsPost "에">> 힘을 뺀다. <<arousal 300 "genitals">>
 	<<else>>/*last one standing*/
-		The <<person1>><<person>> continues working your <<genitals>> with both hands.
+		<<person1>><<person_ ga>> 양손으로 당신의 <<genitals_ rul>> 계속 자극한다.
 		<<set $ft_count to -20>>
 		<<if $arousal gte $arousalmax>><<set $arousal to 9900>><</if>>
 	<</if>>
@@ -2543,36 +2543,36 @@ is an important part of your assessment so you need to be on your best behaviour
 	_crowd
 	<br><br>
 	<<if $ft_count gte 0 or $ft_count is -20>>
-		<<link [[Let yourself enjoy it|Asylum Fake Treatment Masturbation]]>><<arousal 200>><<set $ft_count -=1>><</link>><<garousal>>
+		<<link [[마음껏 즐긴다|Asylum Fake Treatment Masturbation]]>><<arousal 200>><<set $ft_count -=1>><</link>><<garousal>>
 		<br>
 		<<link [[저항한다|Asylum Fake Treatment Masturbation]]>><<arousal -100>><<set $ft_count -=1>><</link>>
 		<br>
 	<<else>>
-		<<link [[Cool off|Asylum Fake Treatment Masturbation]]>><</link>>
+		<<link [[진정한다|Asylum Fake Treatment Masturbation]]>><</link>>
 		<br>
 	<</if>>
 <<else>>
 	<<if $ft_count is 0>>
-		The <<person1>><<person>> finally gives up.
+		<<person1>><<person_ ga>> 마침내 포기한다.
 		<br>
-		"I can't do it," <<he>> says. "<<pShe>> won't cum."
+		"못하겠어," <<he_ ga>> 말한다. "<<pShe_ nun>> 싸지 않을 거야."
 	<<elseif $ft_count lte -20>> /* you won */
-		The <<person1>><<person>> finally gives up.
+		<<person1>><<person_ ga>> 마침내 포기한다.
 		<br>
-		"I can't do it," <<he>> says. "<<pShe>> won't cum."
+		"못하겠어," <<he_ ga>> 말한다. "<<pShe_ nun>> 싸지 않을 거야."
 	<<elseif $ft_count lte -10>> /*someone else won*/
-		As your orgasm resides you hear cheering. You notice the orderlies seem to be exchanging something.
+		당신의 오르가즘이 다가오자 환호성이 들려온다. 잡역부들이 무언가를 주고받고 있다.
 		<br>
 
-		The <<person1>><<person>> wanders into the crowd of orderlies, where they hand <<him>> something. <<He>> smiles back at you.
-		A few moments later, the <<person4>><<person>> beside you starts to shudder as, silently, <<he>> cums
-		<<if $NPCList[0].penis isnot "none">>sending a large spurt of cum toward the mirror <<else>>squirting hard<</if>>
-		and making a mess of the floor in front of <<him>>.
+		<<person1>><<person_ ga>> 잡역부들 사이로 걸어 들어가자, 그들이 <<himPost "에게">> 뭔가를 건넨다. <<He_ ga>> 당신을 돌아보며 미소 짓는다.
+		잠시 후, 옆에 있던 <<person4>><<person_ ga>> 몸을 부르르 떨기 시작하더니, <<he_ ga>>
+		<<if $NPCList[0].penis isnot "none">>조용히 거울을 향해 커다란 정액 덩어리를 내뿜으며 <<else>>힘차게 내뿜으며<</if>>
+		<<him_ yi>> 앞쪽 바닥을 난장판으로 만든다.
 		<br>
-		More orderlies cheer. You see them excitedly passing things between each other.
+		더 많은 잡역부들이 환호한다. 그들이 신나게 서로 물건을 주고받는다.
 	<</if>>
 	<br><br>
-	Finally, you are released from the chair. The <<person1>><<person>> starts to speak.
+	마침내 당신은 의자에서 풀려난다. <<person1>><<person_ gaa>> 말하기 시작한다.
 	<br><br>
 	<<link [[듣는다|Asylum Fake Treatment Finish]]>><<unset $ft_count>><<unset $ft_five>><<unset $ft_four>><</link>>
 <</if>>
@@ -2582,12 +2582,12 @@ is an important part of your assessment so you need to be on your best behaviour
 <<set $outside to 0>><<set $location to "asylum">><<asylumeffects>><<effects>>
 <<pass 5>>
 <<if $ft_count is 5>>
-	The <<fullGroup>> rub themselves off in front of you.
-	Soon the <<person>> cums, squirting <<if $NPCList[0].penis isnot "none">><<bodyliquid "face" "semen">>semen across<<else>><<bodyliquid "face" "goo">>suddenly in<</if>> your face.
-	Another orderly takes <<his>> place as the <<person1>><<person>> reaches climax. The <<person>> stares into your eyes as
-	<<he>> cums, <<his>> fluids splattering against your cheek and running down the collar of your straightjacket.
+	<<fullGroup_ i>> 당신 앞에서 자위하기 시작한다.
+	곧 <<person_ ga>> 사정하며, 당신의 얼굴에 <<if $NPCList[0].penis isnot "none">><<bodyliquid "face" "semen">>정액을<<else>><<bodyliquid "face" "goo">>갑작스럽게<</if>> 내뿜는다.
+	<<person1>><<person_ ga>>절정에 달하자 다른 잡역부가 <<his_ yi>> 자리를 차지한다. The <<person>> stares into your eyes as
+	<<he_ ga>> 당신의 눈을 응시하며 사정을 하고, <<his_ yi>> 정액이 당신의 뺨에 튀면서 당신의 구복속 옷깃으로 흘러내린다.
 	<br>
-	Two more orderlies take <<his>> place.<<if $NPCList[0].penis isnot "none">><<bodyliquid "neck" "semen">><<else>><<bodyliquid "neck" "goo">><</if>>
+	두 잡역부들이 <<his_ yi>> 자리를 차지한다.<<if $NPCList[0].penis isnot "none">><<bodyliquid "neck" "semen">><<else>><<bodyliquid "neck" "goo">><</if>>
 	<br><br>
 	<<if $arousal gte $arousalmax>>
 		<<orgasm>>
@@ -2596,61 +2596,61 @@ is an important part of your assessment so you need to be on your best behaviour
 	<<link [[다음|Asylum Fake Treatment Bukkake]]>><<set $ft_count -= 1>><</link>>
 <<elseif $ft_count gte 1>>
 	<<if $NPCList[0].penis isnot "none">>
-		<<print either("They keep coming and cumming.","You try to keep your mouth shut, but breathing through your nose means you have to smell it.","You're surrounded by grunts and throbbing genitals.","You keep your eyes shut to avoid getting cum in them.")>>
+		<<print either("그들은 계속해서 달아올라 사정한다.","당신은 입을 다물려고 노력하지만 코로 숨을 쉬면 정액 냄새를 맡아야 한다.","당신은 끙끙거리며 고동치는 성기에 둘러싸인다.","당신은 정액이 눈에 들어가지 않도록 눈을 감는다.")>>
 		<<set _goo to "semen">>
 	<<else>>
-		<<print either("They keep coming and cumming.","You try to keep your mouth shut, but it seeps through your lips regardless.","You're surrounded by grunts and slick genitals.","You keep your eyes shut to avoid getting cum in them.")>>
+		<<print either("그들은 계속해서 달아올라 사정한다.","당신은 최대한 입을 다물려고 애쓰지만 그럼에도 불구하고 정액이 입술 사이로 스며든다.","당신은 투덜거리며 매끈한 성기에 둘러싸인다.","당신은 정액이 눈에 들어가지 않도록 눈을 감는다.")>>
 		<<set _goo to "goo">>
 	<</if>>
 	<br>
 	<<set _rand to random(1,9)>>
 	<<if _rand lte 6>>
 		<<if _rand is 1>>
-			Two orderlies manage to simultaneously cum in your face.
+			두 잡역부가 동시에 당신의 얼굴에 사정을 한다.
 			<<faceejacstat>><<ejacstat>><<faceejacstat>><<ejacstat>><<set $hygiene += 500>><<bodyliquid "face" _goo>>
 		<<elseif _rand is 2>>
-			One orderly shoves a hand between your legs and roughly gropes your <<genitals>>.
+			한 잡역부가 당신의 다리 사이로 손을 밀어넣고 당신의 <<genitals_ rul>> 거칠게 더듬는다.
 			<<arousal 200 "genitals">><<pain 5>>
 		<<elseif _rand is 3>>
 			<<if $NPCList[0].penis isnot "none">>
-				One orderly shoves your head against the wall and grinds <<his>> cock against your face until <<he>> ejaculates over you.
+				한 잡역부가 당신의 머리를 벽에 밀치고 <<his_ ga>> 사정할 때까지 당신의 얼굴에 <<he_ yi>> 자지를 마구 비벼댄다.
 			<<else>>
-				One orderly shoves your head against the wall and grinds <<his>> cunt against your face until <<his>> fluids run over you.
+				한 잡역부가 당신의 머리를 벽에 밀치고 <<his_ yi>> 체액이 당신을 뒤덮을 때까지 당신의 얼굴에 <<his_ yi>> 보지를 마구 비벼댄다.
 			<</if>>
 			<<faceejacstat>><<ejacstat>><<set $hygiene += 500>><<bodyliquid "face" _goo>>
 		<<elseif _rand is 4>>
-			Two orderlies masturbate to orgasm either side of you.
+			두 잡역부들이 당신의 양옆에서 오르가즘을 느끼기 위해 자위를 한다.
 			<<hairejacstat>><<ejacstat>><<bodyliquid "hair" _goo>><<neckejacstat>><<ejacstat>><<set $hygiene += 500>><<bodyliquid "neck" _goo>>
 		<<elseif _rand is 5>>
-			One orderly pulls your head up by your hair and <<if $NPCList[0].penis isnot "none">>ejaculates<<else>>squirts<</if>> down the front of your straightjacket.
+			한 잡역부가 당신의 머리채를 잡아당겨 당신의 구속복 앞쪽에 <<if $NPCList[0].penis isnot "none">>사정한다<<else>>내뿜는다</if>>.
 			<<pain 5>><<chestejacstat>><<ejacstat>><<set $hygiene += 500>><<bodyliquid "chest" _goo>>
 		<<else>>
-			One orderly deliberately <<if $NPCList[0].penis isnot "none">>shoots <<his>> load<<else>>squirts <<his>> juices<</if>> in your eye, and
+			한 잡역부가 일부러 당신의 눈에 <<if $NPCList[0].penis isnot "none">><<his_ yi>> 정액을 발사하고<else>><<his_ yi>> 애액을 내뿜고 <</if>>,
 			<<pain 5>><<faceejacstat>><<ejacstat>><<set $hygiene += 500>><<bodyliquid "face" _goo>>
 		<</if>>
 
 		<<if _rand % 3 ==2>>
-			As you try to breathe, you end up taking a mouthful of juices from another.
+			당신은 숨을 쉬려다가 결국 다른 잡역부에게 애액을 한 입 가득 마시게 된다.
 			<<oralejacstat>><<ejacstat>><<if $NPCList[0].penis isnot "none">><<cumswallow "human">><</if>>
 		<<elseif _rand % 3 == 1>>
-			You hear a grunt as juices squirt down your neck.
+			애액이 당신의 목구멍으로 쏟아질 때 끙끙대는 소리가 들린다.
 			<<neckejacstat>><<ejacstat>><<set $hygiene += 500>><<bodyliquid "neck" _goo>>
 		<<else>>
-			A moment later you feel hot juices soak your hair.
+			잠시 후 당신은 뜨거운 애액이 당신의 머리카락을 흠뻑 적시는 것을 느낀다.
 			<<hairejacstat>><<ejacstat>><<set $hygiene += 500>><<bodyliquid "hair" _goo>>
 		<</if>>
 	<<elseif _rand is 7 and ($malechance gte 1 and $cbchance lt 100 or $malechance lt 100 and $dgchance gte 1)>>
-		One orderly tries to shove their cock in your mouth. They're jerked away by another.
+		한 잡역부가 당신의 입에 자신의 자지를 밀어 넣으려고 한다. 그들이 다른 사람에게 홱 끌려간다.
 		<br>
-		"May I remind everyone that any attempt at any kind of penetration will result in removal." <<lstress>><<stress -2>>
+		"어떤 식으로든 삽입을 시도하면 제거될 거라는 걸 모두에게 다시 상기시켜 줘야겠어." <<lstress>><<stress -2>>
 		<br>
 	<</if>><<unset _rand>>
 	<br>
 
 	<<if $submissive gte 1150>>
-		<span class="sub">Being degraded like this makes you feel horny.</span><<ggarousal>><<arousal 666>>
+		<span class="sub">당신은 이런 식으로 모욕을 당하게 되자 흥분을 느낀다.</span><<ggarousal>><<arousal 666>>
 	<<elseif $submissive lte 850>>
-		<span class="brat">You find this 'treatment' humiliating.</span><<garousal>><<arousal 200>><<gstress>><<stress 2>>
+		<span class="brat">당신은 이 '치료'가 굴욕적이라고 생각한다.</span><<garousal>><<arousal 200>><<gstress>><<stress 2>>
 	<<else>>
 		<<garousal>><<arousal 200>>
 	<</if>>
@@ -2660,15 +2660,15 @@ is an important part of your assessment so you need to be on your best behaviour
 	<br><br>
 	<<link [[다음|Asylum Fake Treatment Bukkake]]>><<set $ft_count -= 1>><</link>>
 <<else>>
-	Finally, there are no more.
+	마침내, 더 이상 아무도 오지 않는다.
 	<br>
 	<<if $arousal gte $arousalmax>>
 		<<orgasm>>
 	<<elseif $arousal gte ($arousalmax / 4) * 3 and $submissive gte 1150>>
-		"More," you whimper.
+		"조금만 더," 당신이 속삭인다.
 		<br>
 	<</if>>
-	You feel soaked as fluids ooze down you.
+	액체가 당신의 몸 아래로 흘러내리자 당신은 흠뻑 젖은 듯한 느낌을 받는다.
 	<br><br>
 	<<link [[다음|Asylum Fake Treatment Finish]]>><<unset $ft_count>><</link>>
 <</if>>
@@ -2677,47 +2677,47 @@ is an important part of your assessment so you need to be on your best behaviour
 :: Asylum Fake Treatment Finish
 <<set $outside to 0>><<set $location to "asylum">><<asylumeffects>><<effects>>
 
-"Excellent. Doctor Harper's very pleased with your progress. The doctor asked me to tell you not to mention this treatment to anyone.
-It's very important for your treatment. If you mention it to anyone - even to Doctor Harper <<nnpc_himself "Harper">> - <<nnpc_he "Harper">>
-will be very angry and it will set back your progress. This should be kept secret. Understood?"
+"훌륭해. 하퍼 선생님께서 네 경과에 매우 만족하셨어. 선생님께서 나한테 이 치료법에 대해 아무에게도 말하지 말라고 네게 전해 달라고 하셨어.
+이건 네 치료에 매우 중요해.  이건 네 치료에 매우 중요해. 만약 네가 다른 사람에게 - 심지어 하퍼 선생님 <<nnpc_himselfPost "Harper">> 에게도 이 사실을 얘기한다면 - <<nnpc_he_ nun "Harper">>
+분명 불같이 화를 낼 거고 네 치료에도 차질이 생길 거야. 이건 비밀로 유지돼야 해. 알겠어?"
 <br>
 
 <<if $submissive gte 1150>>
-	You meekly nod.
+	당신은 온순하게 고개를 끄덕인다.
 <<elseif $submissive lte 850>>
-	You wait for <<him>> to get to the point.
+	당신은 <<him_ ga>> 요점을 말할 때까지 기다린다.
 <<else>>
-	You nod once.
+	당신은 고개를 한 번 끄덕인다.
 <</if>>
 <br><br>
 
 <<if $phase is 1 and ($ft_event is "bukkake" or $ft_event is "milk" or $ft_event is "masturbation")>>
-	"Should I take this off?" the <<person2>><<person>> asks, tugging on the straightjacket.
+	"이거 벗겨줄까?" <<person2>><<person_ ga>> 구속복을 잡아당기며 묻는다.
 	<br>
 	<<if $ft_event is "bukkake">>
-		"After the fuss <<pshe>> made about coming here?" <<person1>><<he>> shakes <<his>> head.
-		"Let <<phim>> learn <<pher>> place walking around looking like that for a while."
+		"<<pshe_ ga>> 여기 오자마자 난리를 친 꼴을 보고도?" <<person1>><<he_ ga>> 고개를 절레절레 흔든다.
+		"한동안 <<phim_ rul>> 저런 꼴로 돌아다니게 하면서 <<pher_ yi>> 위치를 깨닫게 해주자."
 		<br>
-		The <<person2>><<person>> laughs.
+		<<person2>><<person_ ga>> 웃는다.
 	<<else>>
-		"After the fuss <<pshe>> made about coming here?" <<person1>><<he>> shakes <<his>> head. "This one needs to learn some obedience."
+		"<<pshe_ ga>> 여기 오자마자 난리를 친 꼴을 보고도?" <<person1>><<he_ ga>> 고개를 절레절레 흔든다. "이 녀석은 복종하는 법을 배워야 해."
 	<</if>>
 <<else>>
-	The <<person2>><<person>> removes the straightjacket.
+	<<person2>><<person_ ga>> 구속복을 벗긴다.
 	<<unbind>><<exposure>><<upperwear 87>>
 <</if>>
 <br><br>
 
 <<if $NPCList[3].description is "long-haired">>
-	<<person4>>The <<person>> is led past you - it feels like you make eye-contact, but it is hard to tell with her face hidden behind her long, matted, messy hair.
+	<<person4>><<person_ ga>> 당신 앞을 지나가면서 - 당신과 눈이 마주친 것 같지만, 그녀의 얼굴이 길고 지저분한 머리카락에 가려져 있어서 잘 보이지 않는다.
 <</if>>
 
 <<if $ft_event is "milk">>
-	As you leave, you notice many of the orderlies have something white around their lips or chin.
+	당신이 떠날 때, 많은 잡역부들이 입술이나 턱 주위에 흰 무언가를 묻힌 채로 있는 것을 발견한다.
 	<br><br>
 <<elseif $ft_event is "masturbation">>
-	As you leave, you notice many orderlies grouped together passing money between them. Some seem happy, others less so.
-	<<print either("One looks","Several look","One glances")>> <<print either("accusingly","crossly","cheerfully","lustfully","hungrily")>> at you.
+	당신이 떠날 때, 많은 잡역부들이 함께 모여서 서로 돈을 주고받는 모습이 보인다. 행복해 보이는 사람도 있고 그렇지 않은 사람도 있다.
+	<<print either("한 명이","여러 명이","한 명이 힐끔")>> <<print either("비난하듯","뿌루퉁하게","쾌활하게","음탕하게","굶주린 듯")>> 당신을 바라본다.
 	<br><br>
 <</if>>
 <<endevent>><<unset $ft_event>>
@@ -2729,30 +2729,30 @@ will be very angry and it will set back your progress. This should be kept secre
 <<npc "Harper">><<person1>>
 <<setKnowsAboutPregnancy "pc" "Harper">>
 
-You awaken in a hospital bed. Several blurry figures move around. One leans closer, <<his>> features coalescing into those of Doctor Harper. "Please don't be alarmed, but your waters have broken. You're still in the asylum."
+당신은 병원 침대에서 깨어난다. 흐릿한 형체들이 이리저리 움직인다. 한 형체가 가까이 다가오더니, <<his_ yi>> 모습이 하퍼 선생님의 모습으로 바뀌었다. "놀라지 말렴, 네 양수가 터졌단다. 넌 아직 정신병원에 있어."
 <br><br>
 
 <<if $exposed lt 2>>
-	"Please undress," the doctor says.
+	"옷을 벗으렴," 의사가 말한다.
 <<else>>
-	"Please take a deep breath," the doctor says.
+	"심호흡 하렴," 의사가 말한다.
 <</if>>
 <<if playerChastity("hidden")>>
-	<<He>> notices your chastity belt, and opens a chest-high cupboard. <<He>> retrieves a tool shaped like a pair of prongs, but bulkier. "We need to remove that device. This won't hurt."
+	<<He_ ga>> 당신의 정조대를 발견하고는 가슴 높이의 찬장을 연다. <<He_ ga>> 갈고리 모양의 부피가 큰 도구를 꺼낸다. "그 장치를 제거해야 해. 아프지 않을 거란다."
 	<br><br>
-	<<He>> grasps your <<print $worn.genitals.name>> with the prongs, and presses a button on the handle. You hear a whirring noise within the tool, <span class="pink">and they snap the metal.</span>
+	<<He_ ga>> 갈고리로 당신의 <<trClothes "genitals" $worn.genitals.name "name" "을">>_trResult 잡고 손잡이에 있는 버튼을 누른다. 도구에서 윙윙 거리는 소리가 들리더니 <span class="pink">금속이 끊어지는 소리가 난다.</span>
 	<<set $worn.genitals.type.push("broken")>>
 <</if>>
 <br><br>
 <<wash>><<undress "asylum_birth">><<upperwear 87 "pink">>
 
-<<link [[Next|Pregnancy Birth Asylum 2]]>><</link>>
+<<link [[다음|Pregnancy Birth Asylum 2]]>><</link>>
 <br>
 
 :: Pregnancy Birth Asylum 2
 <<set $outside to 0>><<set $location to "asylum">><<asylumeffects>><<effects>>
 
-The midwife places a mask over your face. You feel your consciousness fade. Several other figures appear around you, their forms ablur.
+조산사가 당신의 얼굴에 마스크를 씌운다. 당신의 의식이 희미해져 간다. 주변에 다른 여러 인물들이 나타나고 그들의 모습이 흐려진다.
 <br><br>
 
 <<set _pregnancy to getPregnancyObject()>>
@@ -2776,21 +2776,21 @@ The midwife places a mask over your face. You feel your consciousness fade. Seve
 
 <<switch playerNormalPregnancyType()>>
 	<<case "human">>
-		Harper's voice floats through the fog. "Normal human, but keep the others on the line, just in case..."
+		하퍼의 목소리가 안개 속을 떠다닌다. "평범한 인간이지만, 만일을 대비해 다른 사람들을 대기시켜주세요..."
 		<br><br>
 
-		The pain grows as time seems to rapidly speed up and slow down. You hear the words "breathe" and "push" many times, and you do your best to comply.
+		시간이 급격히 빨라지거나 느려지는 것처럼 느껴지면서 통증이 점점 심해진다. 당신은 "숨을 쉬고"와 "힘줘"라는 말을 수차례 들으며 최선을 다해 따른다.
 		<br><br>
 
-		<<link [["Next ("+_hours+":"+(_minutes lt 10 ? "0": "")+_minutes+")"| Pregnancy Birth Asylum 3]]>><<endevent>><<pass _timeCalc>><<playerPrebirth>><</link>>
+		<<link [["다음 ("+_hours+":"+(_minutes lt 10 ? "0": "")+_minutes+")"| Pregnancy Birth Asylum 3]]>><<endevent>><<pass _timeCalc>><<playerPrebirth>><</link>>
 	<<case "wolf">>
-		Harper's voice floats through the fog. "Not human. This will be an abnormal delivery. Follow my instructions to the letter..."
+		하퍼의 목소리가 안개 속을 떠다닌다. "인간이 아니에요. 이것은 비정상적인 출산이 될 겁니다. 제 지시를 철저히 따르세요..."
 		<br><br>
 
-		The pain grows as time seems to rapidly speed up and slow down. You hear the words "breathe" and "push" many times, and you do your best to comply.
+		시간이 급격히 빨라지거나 느려지는 것처럼 느껴지면서 통증이 점점 심해진다. 당신은 "숨을 쉬고"와 "힘줘"라는 말을 수차례 들으며 최선을 다해 따른다.
 		<br><br>
 
-		<<link [["Next ("+_hours+":"+(_minutes lt 10 ? "0": "")+_minutes+")"| Pregnancy Birth Asylum Wolf]]>><<endevent>><<pass _timeCalc>><<playerPrebirth>><</link>>
+		<<link [["다음 ("+_hours+":"+(_minutes lt 10 ? "0": "")+_minutes+")"| Pregnancy Birth Asylum Wolf]]>><<endevent>><<pass _timeCalc>><<playerPrebirth>><</link>>
 <</switch>>
 
 :: Pregnancy Birth Asylum 3
@@ -2798,36 +2798,36 @@ The midwife places a mask over your face. You feel your consciousness fade. Seve
 <<endevent>>
 <<generate1>><<person1>>
 <<set $litter_size to getPregnancyObject().fetus.length>>
-You awaken in another room. A smiling midwife stands beside your bed, 
+당신은 다른 방에서 깨어난다. 미소 띤 조산사가 당신의 침대 옆에 서서, 
 <<if $litter_size is 1>>
-	holding a bundled baby in <<his>> arms.
+	포대기에 싸여 있는 아기를 <<his_ yi>> 품에 안고 있다.
 	<br><br>
 
-	"Looks like mummy's awake," <<he>> says, passing you the baby. They sit in your arms, eyes shut, chest rising and falling with gentle breaths.
+	"엄마가 깨어난 것 같네," <<he_ ga>> 당신에게 아기를 건네며 말한다. 아기는 당신의 팔에 앉아서 눈을 감은 채 가슴을 오르내리며 부드럽게 숨을 쉰다.
 	<br><br>
 
-	"We've run all the tests," the midwife says. "There's not a single health problem. Have you thought of a name?"
+	"모든 검사를 다 했어요," 조산사가 말한다. "건강상 문제는 전혀 없어요. 이름은 생각해 보셨나요?"
 	<br><br>
 
 <<elseif $litter_size is 2>>
-	holding two bundled babies in <<his>> arms.
+	포대기에 싸여 있는 두 명의 아기를 <<his_ yi>> 품에 안고 있다.
 	<br><br>
 
-	"Looks like mummy's awake," <<he>> says, passing you one, and then the other. One sits in each of your arms, eyes shut, chests rising and falling with gentle breaths.
+	"엄마가 깨어난 것 같네," <<he_ ga>> 당신에게 차례로 한 명씩 건네며 말한다. 당신의 양 팔에 앉아 한 명씩 눈을 감은 채 가슴을 오르내리며 부드럽게 숨을 쉰다.
 	<br><br>
 
-	"We've run all the tests," the midwife says. "There's not a single health problem. Have you thought of their names?" the midwife asks.
+	"모든 검사를 다 했어요," 조산사가 말한다. "건강상 문제는 전혀 없어요. 아이들의 이름은 생각해 보셨나요?" 조산사가 묻는다.
 	<br><br>
 
 <<else>>
 
-	holding a trio of bundled babies in <<his>> arms.
+	포대기에 싸여 있는 세 아기를 <<his_ yi>> 품에 안고 있다.
 	<br><br>
 
-	"Looks like mummy's awake," <<he>> says, passing you one, and then another. One sits in each of your arms. The midwife holds the third right in front of your chest. Their eyes are shut, their chests rising and falling with gentle breaths.
+	"엄마가 깨어난 것 같네," <<he_ ga>> 당신에게 차례로 한 명씩 건네며 말한다. 당신의 양 팔에 한 명씩 앉아 있다. 조산사가 세 번째 아기를 당신의 가슴 바로 앞쪽에서 잡아준다. 아기들이 눈을 감은 채 가슴을 오르내리며 부드럽게 숨을 쉰다.
 	<br><br>
 
-	"We've run all the tests," the midwife says. "There's not a single health problem. Have you thought of their names?" the midwife asks.
+	"모든 검사를 다 했어요," 조산사가 말한다. "건강상 문제는 전혀 없어요. 아이들의 이름은 생각해 보셨나요?" 조산사가 묻는다.
 	<br><br>
 <</if>>
 
@@ -2843,117 +2843,117 @@ You awaken in another room. A smiling midwife stands beside your bed,
 <<famepregnancy _pregFame>>
 <<if $litter_size is 1>>
 
-	You cradle your baby for a while longer, enjoying <<childhis>> tiny breaths and movements. <<childHe>> spends most of the time sleeping, but opens <<childhis>> eyes occasionally, and gazes into yours.
+	당신은 한참 동안 아기를 안고 <<childhis_ yi>> 작은 숨소리와 움직임을 즐긴다. <<childHe_ nun>> 대부분의 시간을 자면서 보내지만 가끔 <<childhis_ yi>> 눈을 뜨고 당신의 눈을 바라본다.
 	<br><br>
-	The midwife returns.
+	조산사가 돌아온다.
 
 	<<if $first_birth>>
-		<<He>> teaches you how to change <<childname>>'s nappy, and how to bathe <<childhim>>.
+		<<He_ ga>> <<childname_ yi>> 기저귀를 갈아주는 방법과 <<childhim_ rul>> 목욕시키는 방법을 알려준다.
 	<<else>>
-		<<He>> assists you with changing <<childname>>'s nappy, and bathing <<childhim>>. 
+		<<He_ ga>> <<childname_ yi>> 기저귀 갈아주고 <<childhim_ yi>> 목욕을 도와준다. 
 	<</if>>
-	"Let me know when you're feeling sleepy," <<he>> says. "You need your rest as well, and we can take care of your baby in the meantime."
+	"졸리면 언제든 말해주세요," <<he_ ga>> 말한다. "당신도 휴식이 필요하고, 그동안 아기는 저희가 대신 돌봐 드릴 게요."
 	<br><br>
-	You want nothing more than to hold <<childname>>, but you find yourself dozing all the same.
+	당신은 <<childname_ rul>> 계속 안아주고 싶은 마음은 굴뚝같지만 자꾸만 졸고 있는 자신을 발견한다.
 	<br><br>
 <<elseif $litter_size is 2>>
-	You cradle your babies for a while longer, enjoying their tiny breaths and movements. They spend most of the time sleeping, but open their eyes occasionally, and gaze into yours.
+	당신은 한참 동안 아기들을 안고 아기들의 작은 숨소리와 움직임을 즐긴다. 아기들은 대부분의 시간을 잠을 자면서 보내지만 가끔 눈을 뜨고 당신의 눈을 바라본다.
 	<br><br>
-	The midwife returns.
+	조산사가 돌아온다.
 
 	<<if $first_birth>>
-		<<He>> teaches you how to change their nappies and how to bathe them.
+		<<He_ ga>> 기저귀를 갈아주는 방법과 아기들을 목욕시키는 방법을 알려준다.
 	<<else>>
-		<<He>> assists you with changing their nappies, and with bathing them. 
+		<<He_ ga>> 아기들의 기저귀 갈아주고 목욕을 도와준다.  
 	<</if>>
-	"Let me know when you're feeling sleepy," <<he>> says. "You need your rest as well, and we can take care of your babies in the meantime."
+	"졸리면 언제든 말해주세요," <<he_ ga>> 말한다. "당신도 휴식이 필요하고, 그동안 아기들은 저희가 대신 돌봐 드릴 게요."
 	<br><br>
-	You want nothing more than to hold the twins, but you find yourself dozing all the same.
+	당신은 쌍둥이를 계속 안아주고 싶은 마음은 굴뚝같지만 자꾸만 졸고 있는 자신을 발견한다.
 	<br><br>
 <<elseif $litter_size is 3>>
-	You cradle your babies for a while longer, enjoying their tiny breaths and movements. They spend most of the time sleeping, but open their eyes occasionally, and gaze into yours.
+	당신은 한참 동안 아기들을 안고 아기들의 작은 숨소리와 움직임을 즐긴다. 아기들은 대부분의 시간을 잠을 자면서 보내지만 가끔 눈을 뜨고 당신의 눈을 바라본다.
 	<br><br>
-	The midwife returns.
+	조산사가 돌아온다.
 
 	<<if $first_birth>>
-		<<He>> teaches you how to change their nappies, and how to bathe them.
+		<<He_ ga>> 기저귀를 갈아주는 방법과 아기들을 목욕시키는 방법을 알려준다.
 	<<else>>
-		<<He>> assists you with changing their nappies, and with bathing them. 
+		<<He_ ga>> 아기들의 기저귀 갈아주고 목욕을 도와준다. 
 	<</if>>
-	"Let me know when you're feeling sleepy," <<he>> says. "You need your rest as well, and we can take care of your babies in the meantime."
+	"졸리면 언제든 말해주세요," <<He_ ga>> 말한다. "당신도 휴식이 필요하고, 그동안 아기들은 저희가 대신 돌봐 드릴 게요."
 	<br><br>
-	You want nothing more than to hold the triplets, but you find yourself dozing all the same.
+	당신은 세 쌍둥이를 계속 안아주고 싶은 마음은 굴뚝같지만 자꾸만 졸고 있는 자신을 발견한다.
 	<br><br>
 <</if>>
 
-<<link [[Next|Pregnancy Birth Asylum 5]]>><<storeon "asylum_birth">><<pass 24 hour>><<stress -40>><</link>>
+<<link [[다음|Pregnancy Birth Asylum 5]]>><<storeon "asylum_birth">><<pass 24 hour>><<stress -40>><</link>>
 <br><br>
 
 :: Pregnancy Birth Asylum 5
 <<set $outside to 0>><<set $location to "asylum">><<asylumeffects>><<effects>>
 
-<<if $litter_size gte 2>><<childrenNames $bornChildrenIds>> lie<<else>><<childname>> lies<</if>> in a cradle while the midwife helps you stand.
+<<if $litter_size gte 2>><<childrenNamesPost $bornChildrenIds "가">><<else>><<childname_ ga>><</if>> 요람에 누워 있는 동안 조산사가 당신을 일으켜 세워 준다.
 
 <<if $first_birth or playerNormalPregnancyTotal() is 0>>
-	You feel your insides drop as you stand, but <<he>> assures you that's normal.
+	당신은 서 있을 때 내장이 떨어지는 듯한 느낌을 받지만 <<he_ ga>> 정상적인 현상이라고 단언한다.
 	<br><br>
 
-	Despite the pain, you feel a lot more comfortable walking than you did before the birth. You'd forgotten how easy it is to move without people inside you.
+	통증에도 불구하고 당신은 출산 전보다 훨씬 더 편안하게 걷고 있다고 느낀다. 뱃속에 사람이 없다면 얼마나 쉽게 움직일 수 있는지 까맣게 잊고있었다.
 	<br><br>
 
-	The midwife helps you to dress.
+	조산사가 당신이 옷을 입는 것을 도와준다.
 <<elseif between(playerNormalPregnancyTotal(), 1, 2)>>
-	You feel your insides drop as you stand. You remember this feeling from your last birth, and know it's normal.
+	당신은 서 있을 때 내장이 떨어지는 듯한 느낌을 받는다. 당신은 지난번 출산할 때 느꼈던 이 느낌을 기억하고 있으며, 이것이 정상적인 현상이라는 것을 알고 있다.
 	<br><br>
 
-	Despite the pain, you feel a lot more comfortable walking than you did before the birth. You'd forgotten how easy it is to move without people inside you.
+	통증에도 불구하고 당신은 출산 전보다 훨씬 더 편안하게 걷고 있다고 느낀다. 뱃속에 사람이 없다면 얼마나 쉽게 움직일 수 있는지 까맣게 잊고있었다.
 	<br><br>
 
-	The midwife helps you to dress.
+	조산사가 당신이 옷을 입는 것을 도와준다.
 <<elseif between(playerNormalPregnancyTotal(), 3, 7)>>
-	You feel your insides drop as you stand. You're still not used to the feeling.
+	당신은 서 있을 때 내장이 떨어지는 듯한 느낌을 받는다. 당신은 여전히 그 느낌이 익숙하지 않다.
 	<br><br>
 
-	You get walking again quite easily. It's a little awkward, but the transition isn't as bad as it used to be. It's still easier to move around when there isn't another human inside you.
+	당신은 다시 꽤 쉽게 걸을 수 있게 된다. 조금 어색하지만 변화가 예전처럼 심하지는 않다. 몸 안에 다른 사람이 없을 때 움직이기가 여전히 더 쉬운 것 같다.
 	<br><br>
 
-	The midwife still insists on helping you dress.
+	조산사가 여전히 당신이 옷을 입는 것을 돕겠다고 고집한다.
 <<elseif between(playerNormalPregnancyTotal(), 8, 49)>>
-	You stand up without a hitch. There's hardly any difference in feeling anymore, although you do feel much more nimble.
+	당신은 아무런 어려움 없이 일어선다. 훨씬 더 민첩해진 느낌은 있지만 더 이상 느낌의 차이는 거의 없다.
 	<br><br>
 
-	<<He>> looks impressed at your mobility, only keeping an arm around you for stability. "I don't see many people get back up that quickly. You must be hardy!"
+	<<He_ ga>> 당신의 움직임에 감탄하며 당신의 안정을 위해 팔로 당신을 감싼다. "많은 사람들을 봐왔지만 이렇게 빨리 회복하는 사람은 별로 없었어요. 정말 강인하시네요!"
 	<br><br>
 
-	The midwife still insists on helping you dress.
+	조산사가 여전히 당신이 옷을 입는 것을 돕겠다고 고집한다.
 <<elseif playerNormalPregnancyTotal() gte 50>>
-	You stand up without assistace, feeling empty inside. You already miss the feeling of being pregnant.
+	당신은 누군가의 도움 없이 일어서면서 속이 텅 빈 느낌을 받는다. 당신은 임신했을 때의 느낌이 벌써 그리워진다.
 	<br><br>
 
-	<<He>> stares at you, mouth agape, as you walk without any assistance. You throw your clothes back on quickly.
+	<<He_ ga>> 아무런 도움 없이 걷는 당신을 바라보며 입을 쩍 벌린다. 당신은 재빨리 옷을 다시 입는다.
 	<br><br>
 
-	"Y-you should be good to go," <<he>> says.
+	"ㅇ-이제 가셔도 돼요" <<he_ ga>> 말한다.
 <</if>>
 <<if $innocencestate is 1 or $trauma lte $traumamax / 10>>
-	"Doctor Harper has completed your discharge papers, and you're being released. Someone's waiting for you outside. Your <<if $NPCName[$NPCNameList.indexOf("Bailey")].pronoun is "f">>mum<<else>>dad<</if>> I think."
+	"하퍼 선생님께서 퇴원 서류를 작성하셨으니 이제 퇴원하실 수 있어요. 누군가 밖에서 당신을 기다리고 있어요. 제 생각엔 당신의 <<if $NPCName[$NPCNameList.indexOf("Bailey")].pronoun is "f">>엄마<<else>>아빠<</if>> 같아요"
 	<br><br>
 	<<removeBabyIntro "pc" "Bailey" $recentBirthId>>
-	<<link [[Next|Pregnancy Birth Asylum End]]>><<endevent>><<unset $recentBirthId>><</link>>
+	<<link [[다음|Pregnancy Birth Asylum End]]>><<endevent>><<unset $recentBirthId>><</link>>
 <<else>>
-	"Your children will be sent to the orphanage for temporary care until your release, at which point they will be returned to your custody, once you're deemed mentally fit."
+	"당신의 자녀들은 당신이 퇴원할 때까지 임시 보호를 위해 고아원으로 보내질 거고, 그 후 당신이 정신적으로 건강하다고 판단되면 당신의 품으로 돌아가게 될 거예요."
 	<br><br>
 	<<setBabyIntro "pc" "Bailey" $recentBirthId>>
-	<<link [[Next|Pregnancy Birth Asylum 6]]>><<endevent>><<unset $recentBirthId>><</link>>
+	<<link [[다음|Pregnancy Birth Asylum 6]]>><<endevent>><<unset $recentBirthId>><</link>>
 <</if>>
 
 :: Pregnancy Birth Asylum 6
 <<set $outside to 0>><<set $location to "asylum">><<asylumeffects>><<effects>>
 
-You're returned to your cell. You alreasy miss the embrace of <<childrenNames $bornChildrenIds>>. You feel a renewed sense of determination to leave this place. <<stress -10>><<llstress>><<trauma -10>><<lltrauma>>
+당신은 감방으로 돌아온다. 당신은 벌써 <<childrenNamesPost $bornChildrenIds "의">> 포옹이 그리워진다. 당신은 여길 떠나겠다는 새로운 결심을 하게 된다. <<stress -10>><<llstress>><<trauma -10>><<lltrauma>>
 <br><br>
 
-<<link [[Next|Asylum Cell]]>><<unset $litter_size>><<unset $first_birth>><<endevent>><<unset $bornChildrenIds>><</link>>
+<<link [[다음|Asylum Cell]]>><<unset $litter_size>><<unset $first_birth>><<endevent>><<unset $bornChildrenIds>><</link>>
 <br>
 
 :: Pregnancy Birth Asylum End
@@ -2962,43 +2962,43 @@ You're returned to your cell. You alreasy miss the embrace of <<childrenNames $b
 
 <<npc "Bailey">><<person1>>
 <<getChildrenIds>><<childSelect _childrenIds.last()>>
-Bailey waits for you in front of the asylum. <<He>> smiles when <<he>> sees you. It almost looks real. "We've a place prepared," <<he>> says.
+베일리가 정신병원 앞에서 당신을 기다리고 있다. <<He_ ga>> 당신을 보며 미소 짓는다. 거의 진짜처럼 보인다. "장소를 마련해 뒀어," <<he_ ga>> 말한다.
 <<if $litter_size is 1>>
 
 <<elseif $litter_size is 2>>
-	"For both of them."
+	"두 사람을 위해."
 <<else>>
-	"For all three of them."
+	"세 사람 모두를 위해."
 <</if>>
-<<He>> leads you outside, where <<his>> car waits. <<He>> holds open the passenger door for you, before climbing in the other side.
+<<He_ ga>> 당신을 <<his_ yi>> 바깥으로 데려간다. <<He_ ga>> 당신에게 조수석 문을 열어준 다음 반대쪽에서 올라탄다.
 <br><br>
-The engine comes to life.
+엔진이 작동한다.
 <!-- Bailey may not know about all your pregnancies -->
 <<set _knownPregnancyCount to knowsAboutPregnancyTotal("pc","Bailey","home")>>
 <<if _knownPregnancyCount is 1>>
-	"You're responsible for your offspring's care," <<he>> says. "If I have to intervene, it'll cost you an extra <span class="red">£100</span> a week.<<if $litter_size gte 2>> Each.<</if>>"
+	"넌 네 자식들을 보살필 의무가 있어," <<he_ ga>> 말한다. "만약 내가 개입해야 한다면 추가 비용 <span class="red">£100</span> 를 매주 지불해야 할 거야.<<if $litter_size gte 2>> 가 들 거야.<</if>>"
 	<br><br>
-	"They don't leave the nursery," <<he>> adds as <<he>> drives from the asylum car park into the forest. "Ever."
+	"아기들은 보육원을 벗어나지 못할 거야," <<he_ ga>> 정신병원 주차장에서 숲으로 차를 몰고 가면서 덧붙인다. "영원히."
 <<elseif _knownPregnancyCount lte 4>>
-	"Remember that you're responsible for your offspring's care," <<he>> says. "If I have to intervene, it'll cost you an extra <span class="red">£100</span> a week.<<if $litter_size gte 2>> Each.<</if>>"
+	"넌 네 자식들을 보살필 의무가 있다는 것을 기억해라," <<he_ ga>> 말한다. "만약 내가 개입해야 한다면 추가 비용 <span class="red">£100</span> 를 매주 지불해야 할 거야.<<if $litter_size gte 2>> 가 들 거야.<</if>>"
 	<br><br>
 <<else>>
-	"You're an irresponsible slut," <<he>> says. "Remember that if I have to intervene in the care of your offspring, it'll cost you an extra <span class="red">£100</span> a week.<<if $litter_size gte 2>> Each.<</if>>"
+	"넌 무책임한 걸레야," <<he_ ga>> 말한다. "잊지 마, 만약 내가 네 자식들 돌보는 데 개입해야 한다면 추가 비용 <span class="red">£100</span> 를 매주 지불해야 할 거야.<<if $litter_size gte 2>> 가 들 거야.<</if>>"
 <</if>>
 <<if $baileydefeatedchain gte 3>>
-	You see <<him>> sneer, but only for a brief instant. "I'd rather not make someone else take care of your twerps, but if you keep being a difficult little shit, don't think you'll be allowed to see them again."
+	<<him_ ga>> 비웃는 것이 보이지만 아주 잠깐 동안만이다. "다른 사람에게 네 애새끼들을 돌보라고 하고 싶지 않지만, 만약 네가 계속 까다롭게 굴면 다시는 볼 수 없을 줄 알아라."
 <</if>>
 <br><br>
 
 <<if $litter_size is 1>>
-	<<link [[Tell Bailey your baby's name|Pregnancy Birth Hospital 7]]>><<set $phase to 1>><</link>>
+	<<link [[베일리에게 아기의 이름을 알려준다|Pregnancy Birth Hospital 7]]>><<set $phase to 1>><</link>>
 	<br>
-	<<link [[Just hold the baby tight|Pregnancy Birth Hospital 7]]>><</link>>
+	<<link [[아기를 꽉 안아준다|Pregnancy Birth Hospital 7]]>><</link>>
 	<br>
 <<else>>
-	<<link [[Tell Bailey your babies' names|Pregnancy Birth Hospital 7]]>><<set $phase to 1>><</link>>
+	<<link [[베일리에게 아기들의 이름을 알려준다Pregnancy Birth Hospital 7]]>><<set $phase to 1>><</link>>
 	<br>
-	<<link [[Just hold your babies tight|Pregnancy Birth Hospital 7]]>><</link>>
+	<<link [[아기들을 꽉 안아준다|Pregnancy Birth Hospital 7]]>><</link>>
 	<br>
 <</if>>
 
@@ -3008,25 +3008,25 @@ The engine comes to life.
 <<generate1>><<person1>>
 <<set $litter_size to getPregnancyObject().fetus.length>>
 <<set _baby_type to getPregnancyObject().fetus[0].type>>
-You awaken in another room. You hear faint whimpering. A smiling midwife stands beside your bed, 
+당신은 다른 방에서 깨어난다. 희미하게 낑낑거리는 소리가 들린다. 미소 띤 조산사가 당신의 침대 옆에 서서,
 <<if $litter_size is 1>>
 	holding a bundled _baby_type pup in <<his>> arms.
 	<br><br>
 
-	"Looks like mummy's awake," <<he>> says, passing you the pup. They sit in your arms, eyes shut, chest rising and falling with gentle breaths.
+	"엄마가 깨어난 것 같네," <<he_ ga>> 강아지를 건네며 말한다. 강아지는 당신의 품에 안겨 눈을 감은 채 가슴을 오르락내리락하며 부드럽게 호흡한다.
 	<br><br>
 
-	"We've run all the tests," the midwife says. "There's not a single health problem. Have you thought of a name?"
+	"모든 검사를 다 했어요," 조산사가 말한다. "건강상 문제는 전혀 없어요. 이름은 생각해 봤나요?"
 	<br><br>
 
 <<else>>
 	pushing a cot with <<number $litter_size>> _baby_type pups inside.
 	<br><br>
 
-	"Looks like mummy's awake," <<he>> says, pushing the cot into your reach. You hold them one by one, their eyes shut, chests rising and falling with gentle breaths.
+	"엄마가 깨어난 것 같네," <<he_ ga>> 유아용 침대를 당신의 손이 닿는 곳으로 밀면서 말한다. 당신이 강아지들을 하나하나 안아주자 강아지들은 눈을 감고 가슴을 오르내리며 부드럽게 숨을 내쉰다.
 	<br><br>
 
-	"We've run all the tests," the midwife says. "There's not a single health problem. Have you thought of their names?" the midwife asks.
+	"모든 검사를 다 했어요," 조산사가 말한다. "건강상 문제는 전혀 없어요. 아이들의 이름은 생각해 보셨나요?" 조산사가 묻는다.
 	<br><br>
 
 <</if>>
@@ -3042,74 +3042,74 @@ You awaken in another room. You hear faint whimpering. A smiling midwife stands 
 <<famebestiality $litter_size>>
 <<if $litter_size is 1>>
 
-	You cradle your <<childtype>> for a while longer, enjoying <<childhis>> tiny breaths and movements. <<childHe>> spends most of the time sleeping, but opens <<childhis>> eyes occasionally, and gazes into yours.
+	당신은 한참 동안 <<childtype_ rul>> <<childhis_ yi>> 작은 숨소리와 움직임을 즐긴다. <<childHe_ nun>> 대부분의 시간을 자면서 보내지만 가끔 <<childhis_ yi>> 눈을 뜨고 당신의 눈을 바라본다.
 	<br><br>
-	The midwife returns.
-	"Let me know when you're feeling sleepy," <<he>> says. "You need your rest as well, and we can take care of your pup in the meantime."
+	조산사가 돌아온다.
+	"졸리면 언제든 말해주세요," <<he_ ga>> 말한다. "당신도 휴식이 필요하고, 그 동안 강아지는 저희가 대신 돌봐 드릴 게요."
 	<br><br>
-	You want nothing more than to hold <<childname>>, but you find yourself dozing all the same.
+	당신은 <<childname_ rul>> 계속 안아주고 싶은 마음은 굴뚝같지만 자꾸만 졸고 있는 자신을 발견한다.
 	<br><br>
 <<else>>
-	You cradle your pups for a while longer, enjoying their tiny breaths and movements. They spend most of the time sleeping, but open their eyes occasionally, and gaze into yours.
+	당신은 한참 동안 강아지들을 안고 아기들의 작은 숨소리와 움직임을 즐긴다. 강아지들은 대부분의 시간을 잠을 자면서 보내지만 가끔 눈을 뜨고 당신의 눈을 바라본다.
 	<br><br>
-	The midwife returns.
-	"Let me know when you're feeling sleepy," <<he>> says. "You need your rest as well, and we can take care of your pups in the meantime."
+	조산사가 돌아온다.
+	"졸리면 언제든 말해주세요," <<he_ ga>> 말한다. "당신도 휴식이 필요하고, 그 동안 강아지들은 저희가 대신 돌봐 드릴 게요."
 	<br><br>
-	You want nothing more than to hold them, but you find yourself dozing all the same.
+	당신은 강아지들을 계속 안아주고 싶은 마음은 굴뚝같지만 자꾸만 졸고 있는 자신을 발견한다.
 	<br><br>
 <</if>>
 
-<<link [[Next|Pregnancy Birth Asylum Wolf 3]]>><<storeon "asylum_birth">><<pass 24 hour>><<stress -40>><</link>>
+<<link [[다음|Pregnancy Birth Asylum Wolf 3]]>><<storeon "asylum_birth">><<pass 24 hour>><<stress -40>><</link>>
 <br>
 
 :: Pregnancy Birth Asylum Wolf 3
 <<set $outside to 0>><<set $location to "asylum">><<asylumeffects>><<effects>>
 
-<<if $litter_size gte 2>><<childrenNames $bornChildrenIds>> lie<<else>><<childname>> lies<</if>> in a cradle while the midwife helps you stand.
+<<if $litter_size gte 2>><<childrenNamesPost $bornChildrenIds "가">><<else>><<childname_ ga>><</if>> 요람에 누워 있는 동안 조산사가 당신을 일으켜 세워 준다.
 
 <<if $first_birth or playerNormalPregnancyTotal() is 0>>
-	You feel your insides drop as you stand, but <<he>> assures you that's normal.
+	당신은 서 있을 때 내장이 떨어지는 듯한 느낌을 받지만 <<he_ ga>> 정상적인 현상이라고 단언한다.
 	<br><br>
 
-	Despite the pain, you feel a lot more comfortable walking than you did before the birth. You'd forgotten how easy it is to move without wolves inside you.
+	통증에도 불구하고 당신은 출산 전보다 훨씬 더 편안하게 걷고 있다고 느낀다. 뱃속에 늑대들이 없다면 얼마나 쉽게 움직일 수 있는지 까맣게 잊고있었다.
 	<br><br>
 
-	The midwife helps you to dress.
+	조산사가 당신이 옷을 입는 것을 도와준다.
 <<elseif between(playerNormalPregnancyTotal(), 1, 2)>>
-	You feel your insides drop as you stand. You remember this feeling from your last birth, and know it's normal.
+	당신은 서 있을 때 내장이 떨어지는 듯한 느낌을 받는다. 당신은 지난번 출산할 때 느꼈던 이 느낌을 기억하고 있으며, 이것이 정상적인 현상이라는 것을 알고 있다.
 	<br><br>
 
-	Despite the pain, you feel a lot more comfortable walking than you did before the birth. You'd forgotten how easy it is to move without wolves inside you.
+	통증에도 불구하고 당신은 출산 전보다 훨씬 더 편안하게 걷고 있다고 느낀다. 뱃속에 늑대들이 없다면 얼마나 쉽게 움직일 수 있는지 까맣게 잊고있었다.
 	<br><br>
 
-	The midwife helps you to dress.
+	조산사가 당신이 옷을 입는 것을 도와준다.
 <<elseif between(playerNormalPregnancyTotal(), 3, 7)>>
-	You feel your insides drop as you stand. You're still not used to the feeling.
+	당신은 서 있을 때 내장이 떨어지는 듯한 느낌을 받는다. 당신은 여전히 그 느낌이 익숙하지 않다.
 	<br><br>
 
-	You get walking again quite easily. It's a little awkward, but the transition isn't as bad as it used to be. It's still easier to move around when there isn't a litter of wolves inside you.
+	당신은 다시 꽤 쉽게 걸을 수 있게 된다. 조금 어색하지만 변화가 예전처럼 심하지는 않다. 몸 안에 다른 늑대들이 없을 때 움직이기가 여전히 더 쉬운 것 같다.
 	<br><br>
 
-	The midwife still insists on helping you dress.
+	조산사가 여전히 당신이 옷을 입는 것을 돕겠다고 고집한다.
 <<elseif between(playerNormalPregnancyTotal(), 8, 49)>>
-	You stand up without a hitch. There's hardly any difference in feeling anymore, although you do feel much more nimble.
+	당신은 아무런 어려움 없이 일어선다. 훨씬 더 민첩해진 느낌은 있지만 더 이상 느낌의 차이는 거의 없다.
 	<br><br>
 
-	<<He>> looks impressed at your mobility, only keeping an arm around you for stability. "I don't see many people get back up that quickly. You must be hardy!"
+	<<He_ ga>> 당신의 움직임에 감탄하며 당신의 안정을 위해 팔로 당신을 감싼다. "많은 사람들을 봐왔지만 이렇게 빨리 회복하는 사람은 별로 없었어요. 정말 강인하시네요!"
 	<br><br>
 
-	The midwife still insists on helping you dress.
+	조산사가 여전히 당신이 옷을 입는 것을 돕겠다고 고집한다.
 <<elseif playerNormalPregnancyTotal() gte 50>>
-	You stand up without assistace, feeling empty inside. You already miss the feeling of being pregnant.
+	당신은 누군가의 도움 없이 일어서면서 속이 텅 빈 느낌을 받는다. 당신은 임신했을 때의 느낌이 벌써 그리워진다.
 	<br><br>
 
-	<<He>> stares at you, mouth agape, as you walk without any assistance. You throw your clothes back on quickly.
+	<<He_ ga>> 아무런 도움 없이 걷는 당신을 바라보며 입을 쩍 벌린다. 당신은 재빨리 옷을 다시 입는다.
 	<br><br>
 
-	"Y-you should be good to go," <<he>> says.
+	"ㅇ-이제 가셔도 돼요" <<he_ ga>> 말한다.
 <</if>>
-"The pups will be released into the forest once they can fend for themselves."
+"강아지들은 스스로를 보호할 수 있게 되면 숲으로 방생될 거예요."
 <br><br>
 
-<<link [[Next|Pregnancy Birth Asylum 6]]>><<endevent>><</link>>
+<<link [[다음|Pregnancy Birth Asylum 6]]>><<endevent>><</link>>
 <br>


### PR DESCRIPTION
game\overworld-forest\loc-asylum\main.twee
------
598번 줄을 시작으로 미번역된 부분을 전체적으로 번역했습니다.

의역, 오역들이 굉장히 많고 중간에 영어 원문을 봐야만 이해할 수 있는 단어를 이용한 농담이 있지만 일단 대충 번역은 해뒀습니다.

한번 훑어 보긴 했지만 중간중간 미번역 부분이 있을 수도 있으며,

2303, 2505, 2506, 2508, 2509, 2520, 2521, 2523, 3013, 3023 줄은 대화 중간에 <<>>가 아닌 _로 시작하는 코드가 껴있길래 제가 건드렸다간 오류가 날 거 같아서 건드려도 괜찮을 것 같은 부분만 조금 번역해두고 나머지는 손대지 않았습니다.

또한 2743 줄은 이미 번역된 부분을 참고하여 바꿔놨지만 제가 제대로 적은 게 맞는지 봐주시면 감사하겠습니다.