### PR TITLE
loc-farm/assault.twee 및 관련 부분 번역

### DIFF
--- a/game/overworld-plains/loc-farm/assault.twee
+++ b/game/overworld-plains/loc-farm/assault.twee
@@ -2,30 +2,30 @@
 <<set $outside to 1>><<set $location to "alex_farm">><<effects>>
 <<farm_work_update>>
 <<if $farm_assault.movement is "field">>
-	You keep low as you hurry across the farm.
+	당신은 몸을 낮춘 채 서둘러 농장을 가로지른다.
 <<elseif $farm_assault.movement is "tower">>
-	You keep low as you hurry towards the watchtower.
+	당신은 몸을 낮춘 채 서둘러 망루로 향한다.
 <<elseif $farm_assault.movement is "climb">>
-	You enter the watchtower. The stairs creak as you climb.
+	당신은 망루를 올라간다. 계단을 올라갈 때마다 삐걱거리는 소리가 난다.
 <<elseif $farm_assault.movement is "wait">>
-	You wait in the shadows, watching for intruders.
+	당신은 그림자 속에 숨어서, 깡패들을 지켜보며 기다린다.
 <<elseif $farm_assault.movement is "struggle">>
 	<<if $farm_assault.bindings lte 0>>
-		You struggle against your bindings. <span class="green">They come loose.</span>
-		<<if $worn.face.type.includes("gag")>>You tear the gag from your mouth.<</if>>
+		당신은 구속을 풀기 위해 몸부림친다. <span class="green">마침내 결박이 풀린다.</span>
+		<<if $worn.face.type.includes("gag")>>당신은 입에서 재갈을 뜯어낸다.<</if>>
 		<<if $farm_assault.alex is "bound">>
 			<<npc Alex>><<person1>>
-			You find Alex not far away, remove the gag from <<his>> mouth, and untie <<his>> bonds. "Fuckers," <<he>> says. "There's no time to waste."
+			당신은 멀지 않은 곳에서 알렉스를 발견하고, <<his_ yi>> 입에서 재갈을 빼고 구속을 풀어준다. "개자식들." <<he_ ga>> 말한다. "낭비할 시간이 없어."
 			<<set $farm_assault.bindings_alex to 0>>
 			<<set $farm_assault.alex to "patrol">>
 			<<endevent>>
 		<</if>>
 		<<farm_assault_unbind>>
 	<<else>>
-		You struggle against your bindings. <span class="teal">They feel a little looser.</span>
+		당신은 구속을 풀기 위해 몸부림친다. <span class="teal">조금 느슨해진 것 같다.</span>
 	<</if>>
 <<else>>
-	You keep your head on a swivel, watching for intruders.
+	당신은 깡패들을 지켜보며 주위를 살핀다.
 <</if>>
 <<set $farm_assault.movement to "none">>
 <br><br>
@@ -35,14 +35,14 @@
 <<farm_assault_alex>>
 
 <<if _smoke>>
-	<span class="red">You smell smoke on the breeze.</span>
+	<span class="red">바람 속에서 연기 냄새가 난다.</span>
 	<br><br>
 <</if>>
 
 <<if $farm_assault.tower is "manned" or $farm_assault.tower is "attacked" or _guard_won is true or _guard_lost is true>>
 	<<farm_assault_info guard>>
 <<elseif $farm_assault.tower is "defeated">>
-	<span class="red">$farm.tower_guard has been defeated, and can't help for the remainder of the assault.</span>
+	<span class="red"><<NPCname_ nun $farm.tower_guard>> 패배했다. 남은 습격을 도와줄 수 없을 것이다.</span>
 	<br><br>
 <</if>>
 
@@ -51,30 +51,30 @@
 <</if>>
 
 <<if _dogs_status is "victorious">>
-	<span class="green">You hear a triumphant howling.</span>
+	<span class="green">개들의 의기양양한 울음소리가 들린다.</span>
 	<br><br>
 <<elseif _dogs_status is "defeated">>
-	<span class="red">You hear a panicked howling.</span>
+	<span class="red">개들의 겁에 질린 울음소리가 들린다.</span>
 	<br><br>
 <</if>>
 
 <<if $farm_destroyed is true>>
 	<<farm_assault_unbind>>
 	<<if $fields_damaged is 0>>
-		<span class="purple">With no fields to burn, the thugs flee the field.</span><<lcontrol>><<gtrauma>><<control -10>><<trauma 6>>
+		<span class="purple">어떤 밭도 태우지 못한 채 깡패들이 들판을 달아난다.</span><<lcontrol>><<gtrauma>><<control -10>><<trauma 6>>
 		<br><br>
 		<<npc Remy>><<person1>>
-		Remy watches from a nearby hill. <<He>> turns <<his>> steed and rides away.
+		레미가 근처 언덕에서 지켜보다가, <<his_ yi>> 말의 방향을 돌려 떠난다.
 		<br><br>
 		<<endevent>>
 		<<link [[다음|Farm Assault Victory]]>><</link>>
 		<br>
 	<<else>>
-		<span class="red">Their job done, the thugs flee the fields, leaving a smoldering waste behind them.</span>
+		<span class="red">그들은 할 일을 마쳤다. 깡패들은 연기가 자욱한 불모지를 뒤로 하고 들판을 달아난다.</span>
 		<<lllcontrol>><<gggtrauma>><<control -50>><<trauma 24>>
 		<br><br>
 		<<npc Remy>><<person1>>
-		Remy watches from a nearby hill. <<He>> turns <<his>> steed and rides away.
+		레미가 근처 언덕에서 지켜보다가, <<his_ yi>> 말의 방향을 돌려 떠난다.
 		<br><br>
 		<<endevent>>
 		<<link [[다음|Farm Assault Defeat]]>><</link>>
@@ -82,20 +82,20 @@
 	<</if>>
 <<elseif _farm_assault_active isnot true>>
 	<<farm_assault_unbind>>
-	<span class="green">Driven back, the thugs flee the farm.</span>
+	<span class="green">격퇴된 깡패들이 들판을 달아난다.</span>
 	<<if $fields_damaged gte 2>>
-		<span class="pink">They managed to torch <<number $fields_damaged>> fields.</span><<llcontrol>><<ggtrauma>><<control -25>><<trauma 12>>
+		<span class="pink">그들은 <<trNumber $fields_damaged>> 개의 밭에 불을 질렀다.</span><<llcontrol>><<ggtrauma>><<control -25>><<trauma 12>>
 	<<elseif $fields_damaged gte 1>>
-		<span class="blue">They managed to torch a field.</span><<lcontrol>><<gtrauma>><<control -10>><<trauma 6>>
+		<span class="blue">그들은 하나의 밭에 불을 질렀다.</span><<lcontrol>><<gtrauma>><<control -10>><<trauma 6>>
 	<<else>>
-		<span class="green">They failed to torch a single field.</span><<ggcontrol>><<lltrauma>><<control 25>><<trauma -25>>
+		<span class="green">그들은 단 하나의 밭도 불사르지 못했다.</span><<ggcontrol>><<lltrauma>><<control 25>><<trauma -25>>
 		<<if $farm_stage gte 12>>
 			<<earnFeat "Heroic Victory">>
 		<</if>>
 	<</if>>
 	<br><br>
 	<<npc Remy>><<person1>>
-	Remy watches from a nearby hill. <<He>> turns <<his>> steed and rides away.
+	레미가 근처 언덕에서 지켜보다가, <<his_ yi>> 말의 방향을 돌려 떠난다.
 	<br><br>
 	<<endevent>>
 	<<link [[다음|Farm Assault Victory]]>><</link>>
@@ -111,59 +111,59 @@
 <<effects>>
 
 <<npc Alex>><<person1>>
-You find Alex lying on <<his>> face, an empty bottle beside <<him>>. <<Hes>> unconscious.<<llldom>><<npcincr Alex dom -15>>
+당신은 알렉스가 빈 병과 함께 엎드려 있는 것을 발견한다. <<he_ nun>> 의식이 없다.<<llldom>><<npcincr Alex dom -15>>
 <br><br>
 
 <<if $farm_assault.tower is "defeated">>
-	You carry <<him>> back to the cottage, and lay <<him>> in <<his>> bed, before returning to search for $farm.tower_guard.
+	당신은 <<NPCname_ rul $farm.tower_guard>> 찾으러 돌아가기 전에, <<he_ rul>> 농가로 옮긴 뒤 <<his_ yi>> 침대에 눕힌다.
 	<<endevent>>
 	<<loadNPC 0 "farm_tower_guard">><<person1>>
-	You find <<him>> sitting at the base of the watchtower,
+	당신은 망루 밑에 앉아 있는 <<him_ ul>> 발견한다.
 	<<if $NPCList[0].traits.includes("relaxed")>>
-		trying to light a cigarette butt. "That was rougher than I expected," <<he>> says. "Could you help me up?"
+		<<he_ nun>> 담배꽁초에 불을 붙이려 하고 있다. "내가 생각했던 것보다 훨씬 거칠었어." <<he_ ga>> 말한다. "일어서는 것 좀 도와줄래?"
 	<<elseif $NPCList[0].traits.includes("sociable")>>
-		chatting on <<his>> phone. "-boss is here. Call you back." <<He>> smiles at you. "You should have seen how many I took on before they got me."
+		<<he_ nun>> <<his_ yi>> 휴대전화로 수다를 떨고 있다. "-보스가 왔어. 나중에 전화할게." <<He_ nun>> 당신을 향해 웃어보인다. "그들한테 붙잡히기 전에 내가 몇 명이나 상대했는지 봤어야 하는데."
 	<<elseif $NPCList[0].traits.includes("brooding")>>
-		gazing at the sky. "Sorry boss," <<he>> says. "I like to think I gave as good as I got."
+		<<he_ nun>> 하늘을 바라보고 있다. "미안해 보스," <<he_ ga>> 말한다. "내가 받은 만큼은 도움이 됐다고 믿고 싶네."
 	<<else>>
-		watching you. "Are you an angel come to take me away?" <<he>> laughs.
+		<<he_ nun>> 당신을 바라본다. "천사가 날 데리러 온 건가?" <<he_ ga>> 웃는다.
 	<</if>>
-	You help <<him>> to <<his>> feet.
+	당신은 <<he_ ga>> 일어서는 것을 돕는다.
 	<<if $NPCList[0].traits.includes("relaxed")>>
-		"I'll be alright" <<he>> continues. "Just need to stretch."
+		"난 괜찮아." <<he_ ga>> 이어 말한다. "그냥 스트레칭 좀 하면 돼."
 	<<elseif $NPCList[0].traits.includes("sociable")>>
-		"There's a stool just inside," <<he>> continues. "A little rest would do me good."
+		"안에 의자가 있거든," <<he_ ga>> 이어 말한다. "나는 약간 쉬는 게 좋겠어."
 	<<elseif $NPCList[0].traits.includes("brooding")>>
-		"Don't worry about me," <<he>> continues. "I'll walk it off."
+		"내 걱정은 하지 마," <<he_ ga>> 이어 말한다. "바람 좀 쐬면 돼."
 	<<else>>
-		"Your touch has me feeling better already," <<he>> continues. "I think I can limp back to my post."
+		"네 손길 덕분에 벌써 기분이 나아졌어," <<he_ ga>> 이어 말한다. "좀 느리긴 해도 내 자리로 돌아갈 수 있을 것 같아."
 	<</if>>
 	<br><br>
-	You return to the cottage. Remy won this round, but the war continues.
+	당신은 농가로 돌아간다. 이번에는 레미가 이겼지만, 싸움은 계속될 것이다.
 	<br><br>
 <<elseif $farm_assault.tower is "manned" or $farm_assault.tower is "attacked">>
-	$farm.tower_guard limps over.
+	<<NPCname_ ga $farm.tower_guard>> 절뚝거리며 다가온다.
 
 	<<endevent>>
 	<<loadNPC 0 "farm_tower_guard">><<person1>>
 
 	<<if $NPCList[0].traits.includes("relaxed")>>
-		"Let's get <<nnpc_him Alex>> inside," <<he>> says, nodding at Alex. "Then I need a smoke."
+		"<<nnpc_him_ rul Alex>> 안으로 옮기자," <<he_ ga>> 알렉스를 향해 고개를 까닥이며 말한다. "그러고 나서 담배 좀 피워야겠어."
 	<<elseif $NPCList[0].traits.includes("sociable")>>
-		"Is <<nnpc_he Alex>> alright?" <<he>> asks, then notices the bottle. "Ah."
+		"<<nnpc_he_ nun Alex>> 괜찮아?" <<he_ ga>> 묻다가, 병을 발견한다. "아."
 	<<elseif $NPCList[0].traits.includes("brooding")>>
-		"Sorry boss," <<he>> says. "You're handling this better than Alex at least. Let's get <<nnpc_him Alex>> inside."
+		"미안해 보스," <<he_ ga>> 말한다. "그래도 알렉스보다 훨씬 잘 감당하고 있네. <<nnpc_him_ rul Alex>> 안으로 옮기자."
 	<<else>>
-		"That was a mess," <<he>> says. "Alex has the right idea. Odd choice of bed though."
+		"엉망진창이네," <<he_ ga>> 말한다. "알렉스는 잘 생각한 거야. 침대를 잘못 고르긴 했지만."
 	<</if>>
 	<br><br>
 
 	<<endevent>>
 	<<npc Alex>><<person1>>
-	Together, you carry Alex back to the cottage, and lay <<him>> in <<his>> bed. Remy won this round, but the war continues.
+	당신은 <<NPCname_ gwa $farm.tower_guard>> 함께 알렉스를 농가로 옮긴 뒤 <<his_ yi>> 침대에 눕힌다. 이번에는 레미가 이겼지만, 싸움은 계속될 것이다.
 	<br><br>
 <<else>>
-	You carry <<him>> back to the cottage, and lay <<him>> in <<his>> bed. Remy won this round, but the war continues.
+	당신은 <<he_ rul>> 농가로 옮긴 뒤 <<his_ yi>> 침대에 눕힌다. 이번에는 레미가 이겼지만, 싸움은 계속될 것이다.
 	<br><br>
 <</if>>
 
@@ -180,55 +180,55 @@ You find Alex lying on <<his>> face, an empty bottle beside <<him>>. <<Hes>> unc
 <<npc Alex>><<person1>>
 
 <<if $farm_destroyed is true>>
-	"You better stay the fuck away," Alex shouts after them. <<He>> turns to you. "I'm glad they wasted their time, but we shouldn't let them run rampant through the farm."
+	"썩 꺼지는 게 좋을 거야," 알렉스가 그들에게 소리친다. <<He_ ga>> 당신을 돌아본다. "그들이 시간을 허비해서 다행이야. 하지만 그들이 농장을 마구 헤집고 다니도록 놔두면 안돼."
 	<br><br>
 <<elseif $fields_damaged gte 1>>
-	"You better stay the fuck away," Alex shouts after them. <<He>> turns to you, then to the smoldering field behind <<him>>. "We limited the damage," <<he>> says. "We'll be more prepared next time."
+	"썩 꺼지는 게 좋을 거야," 알렉스가 그들에게 소리친다. <<He_ nun>> 당신을, 그리고 연기가 피어오르는 밭을 돌아본다. "우리는 피해를 최소화했어." <<he_ ga>> 말한다. "다음에는 더 단단히 준비할 거야."
 	<br><br>
 <<else>>
-	"You better stay the fuck away," Alex shouts after them. <<He>> turns to you. Mud coats <<his>> body, but <<his>> smile is broad. "We did it. And we can do it again!"
+	"썩 꺼지는 게 좋을 거야," 알렉스가 그들에게 소리친다. <<He_ ga>> 당신을 돌아본다. 진흙이 <<his_ yi>> 몸을 온통 뒤덮었는데도 <<he_ nun>> 활짝 웃는다. "우리가 해냈어. 그리고 다음에도 해낼 수 있을 거야!"
 	<br><br>
 <</if>>
 
 <<if $farm_assault.tower is "defeated">>
-	<<He>> looks at the watchtower. "Fuck, is $farm.tower_guard okay?"
+	<<He_ ga>> 망루를 바라본다. "젠장, <<NPCname_ nun $farm.tower_guard>> 괜찮을까?"
 	<br><br>
 	<<endevent>>
 	<<loadNPC 0 "farm_tower_guard">><<person1>>
-	You find the lookout sat at the base of the tower,
+	당신은 망루 밑에 앉아 있는 경비원을 발견한다.
 	<<if $NPCList[0].traits.includes("relaxed")>>
-		trying to light a cigarette butt. "That was rougher than I expected," <<he>> says. "Could you help me up?"
+		<<he_ nun>> 담배꽁초에 불을 붙이려 하고 있다. "내가 생각했던 것보다 훨씬 거칠었어." <<he_ ga>> 말한다. "일어서는 것 좀 도와줄래?"
 	<<elseif $NPCList[0].traits.includes("sociable")>>
-		chatting on <<his>> phone. "-bosses are here. Call you back." <<He>> smiles at you. "You should have seen how many I took on before they got me."
+		<<he_ nun>> <<his_ yi>> 휴대전화로 수다를 떨고 있다. "-보스들이 왔어. 나중에 전화할게." <<He_ ga>> 웃어보인다. "그들한테 붙잡히기 전에 내가 몇 명이나 상대했는지 봤어야 하는데."
 	<<elseif $NPCList[0].traits.includes("brooding")>>
-		gazing at the sky. "Sorry boss," <<he>> says. "I like to think I gave as good as I got."
+		<<he_ nun>> 하늘을 바라보고 있다. "미안해 보스," <<he_ ga>> 말한다. "내가 받은 만큼은 도움이 됐다고 믿고 싶네."
 	<<else>>
-		watching you. "Have the angels come to take me away?" <<he>> laughs.
+		<<he_ ga>> 이쪽을 바라본다. "천사들이 날 데리러 온 건가?" <<he_ ga>> 웃으며 말한다.
 	<</if>>
-	You and Alex help <<him>> to <<his>> feet.
+	당신과 알렉스는 <<he_ ga>> 일어서는 것을 돕는다.
 	<<if $NPCList[0].traits.includes("relaxed")>>
-		"I'll be alright" <<he>> continues. "Just need to stretch."
+		"난 괜찮아." <<he_ ga>> 이어 말한다. "그냥 스트레칭 좀 하면 돼."
 	<<elseif $NPCList[0].traits.includes("sociable")>>
-		"There's a stool just inside," <<he>> continues. "A little rest would do me good."
+		"안에 의자가 있거든," <<he_ ga>> 이어 말한다. "나는 약간 쉬는 게 좋겠어."
 	<<elseif $NPCList[0].traits.includes("brooding")>>
-		"Don't worry about me," <<he>> continues. "I'll walk it off."
+		"내 걱정은 하지 마," <<he_ ga>> 이어 말한다. "바람 좀 쐬면 돼."
 	<<else>>
-		"Your touch has me feeling better already," <<he>> continues. "I think I can limp back to my post."
+		"네 손길 덕분에 벌써 기분이 나아졌어," <<he_ ga>> 이어 말한다. "좀 느리긴 해도 내 자리로 돌아갈 수 있을 것 같아."
 	<</if>>
 	<br><br>
 
 <<elseif $farm_assault.tower is "manned" or $farm_assault.tower is "attacked">>
-	$farm.tower_guard approaches.
+	<<NPCname_ ga $farm.tower_guard>> 다가온다.
 	<<endevent>>
 	<<loadNPC 0 "farm_tower_guard">><<person1>>
 	<<if $NPCList[0].traits.includes("relaxed")>>
-		"Glad you guys are alright,"<<he>> says. "That was almost too exciting."
+		"너희들이 무사해서 다행이야," <<he_ ga>> 말한다. "지나칠 정도로 흥미진진했어."
 	<<elseif $NPCList[0].traits.includes("sociable")>>
-		"That livened things up," <<he>> says. "I think I need a breather."
+		"일에 활기를 불어넣어주네." <<he_ ga>> 말한다. "난 잠깐 쉬어야겠어."
 	<<elseif $NPCList[0].traits.includes("brooding")>>
-		"Good job," <<he>> says. "Hope I helped."
+		"수고했어," <<he_ ga>> 말한다. "내가 도움이 됐으면 좋겠네."
 	<<else>>
-		"You should've seen me up there," <<he>> says. "Three-" <<He>> pauses. "I mean, five, burly monsters came climbing the side of the tower, but I sent them packing."
+		"저 위에서 날 봤어야 했어," <<he_ ga>> 말한다. "세 명-" <<He_ nun>> 잠시 말을 멈춘다. "아니, 다섯은 되는 건장한 괴물들이 망루를 기어 올라왔는데, 내가 다 짐 싸게 만들었다고."
 	<</if>>
 	<br><br>
 <<else>>
@@ -237,15 +237,15 @@ You find Alex lying on <<his>> face, an empty bottle beside <<him>>. <<Hes>> unc
 
 <<endevent>>
 <<npc Alex>><<person1>>
-You walk back to the cottage.
+당신은 농가로 돌아온다.
 <<if isLoveInterest("Alex")>>
-	Alex wraps an arm around your shoulder.
+	알렉스가 팔로 당신의 어깨를 감싼다.
 <<else>>
-	Alex pats your shoulder.
+	알렉스가 당신의 어깨를 토닥인다.
 <</if>>
-"We won, but Remy will be back. We'll be ready."
+"우리가 이겼어. 하지만 레미는 돌아올 거야. 우리는 준비되어 있어야 해."
 <br><br>
-<span class="red">Remy will attack again in <<number $farm_attack_timer>> days.</span>
+<span class="red">레미는 $farm_attack_timer일 뒤에 다시 습격해올 것이다.</span>
 <br><br>
 
 <<unset $fields_damaged>>
@@ -260,23 +260,23 @@ You walk back to the cottage.
 <<set $bus to "yard">>
 <<farm_assault_init>>
 
-You rush outside, and find Alex stood in the yard.
+밖으로 뛰쳐나오니, 마당에 서 있는 알렉스가 보인다.
 <br><br>
 <<set $farm_attack_timer to random(17, 24)>>
 <<npc Alex>><<person1>>
-"They're not coming through here," <<he>> says, nodding at the road. "They'll try to sneak in." <<He>> hands you a walkie talkie. "There's a lot of ground to cover, so we'll need to split up. We'll be stronger if we team up to fight them though."
+"그들은 이쪽으로 들어오지 않을 거야," <<He_ ga>> 도로를 향해 고개를 까닥이며 말한다. "몰래 들어오려고 하겠지." <<He_ nun>> 당신에게 무전기를 건네준다. "지켜야 할 땅이 많으니 찢어져서 활동해야겠어. 우리가 힘을 합쳐 싸우면 그들보다 강하겠지만 말이야."
 
 <<if $farm.tower gte 2 and $farm.tower_guard>>
-	<<He>> waves at the watchtower, and $farm.tower_guard flashes the searchlight in response.
+	<<He_ ga>> 망루를 향해 손을 흔든다. <<NPCname_ nun $farm.tower_guard>> 이에 응답하여 탐조등을 깜박인다.
 <<elseif $farm.tower and $farm.tower_guard>>
-	<<He>> waves at the watchtower, and you make out $farm.tower_guard wave in response.
+	<<He_ ga>> 망루를 향해 손을 흔든다. 당신은 <<NPCname_ ga $farm.tower_guard>> 마주 손을 흔드는 것을 본다.
 <<elseif $farm.tower>>
-	<<He>> points at the watchtower. "We can climb it if we need a better view."
+	<<He_ ga>> 망루를 가리킨다. "넓은 시야가 필요하다면 올라갈 수 있어."
 <</if>>
 <br><br>
 
 <<if $leftarm is "bound" or $rightarm is "bound">>
-	Alex slices through your bindings. You're not defending the farm like that.
+	알렉스가 당신의 구속을 잘라낸다. 이런 식으로 농장을 방어할 수는 없다.
 	<<unbind>>
 	<br><br>
 <</if>>
@@ -290,16 +290,16 @@ You rush outside, and find Alex stood in the yard.
 <<effects>>
 
 <<if $phase is 2>>
-	You enter the cottage, climb the stairs, and throw open the rustic wadrobe.
+	당신은 농가에 들어가, 계단을 오르고, 소박한 옷장을 열어젖힌다.
 <<elseif $phase is 1>>
-	You climb from your bed, and throw open the rustic wardrobe.
+	당신은 침대에서 일어나, 소박한 옷장을 열어젖힌다.
 <<elseif $phase is 3>>
-	You enter your room, and throw open the rustic wardrobe.
+	당신은 당신의 방으로 들어가, 소박한 옷장을 열어젖힌다.
 <<else>>
-	You look through the rustic wardrobe.
+	당신은 소박한 옷장을 들여다본다.
 <</if>>
 <<set $phase to 0>>
-You hear shouting outside.
+밖에서 외치는 소리가 들린다.
 <br><br>
 <<set $wardrobe_location to "alexFarm">>
 <<wardrobeSelection>>
@@ -594,25 +594,25 @@ You hear shouting outside.
 	<</for>>
 
 	<<if _fighting is true or _guard_won is true or _guard_lost is true>>
-		Your walkie talkie picks up another signal. <span class="red">You hear a struggle, punctuated by static.</span>
+		당신의 무전기가 다른 신호를 수신한다. <span class="red">당신은 잡음 속에서 몸싸움 소리를 듣는다.</span>
 		<<if _guard_won is true>>
-			You peer at the watchtower. A body falls from the top. <span class="green">It's not $farm.tower_guard.</span> Seems they got the better of one of their attackers.
+			당신은 망루를 주의 깊게 바라본다. 꼭대기에서 사람이 떨어진다. <span class="green"><<NPCname_ ga $farm.tower_guard>> 아니다.</span> 공격자 중 한 명을 이긴 것 같다.
 		<<elseif _guard_lost is true>>
-			You peer at the watchtower. A body falls from the top. <span class="red">It's $farm.tower_guard.</span> They won't be helping for the rest of the assault.
+			당신은 망루를 주의 깊게 바라본다. 꼭대기에서 사람이 떨어진다. <span class="red"><<NPCname_ da $farm.tower_guard>>.</span> 남은 공격에는 도움이 되지 못할 것이다.
 		<</if>>
 		<br><br>
 	<<else>>
 		<<if _args[0] is "guard">>
-			Your walkie talkie picks up another signal. It's $farm.tower_guard, keeping you informed of enemy activity:
+			당신의 무전기가 다른 신호를 수신한다. <<NPCname_ da $farm.tower_guard>>. 당신에게 적의 움직임을 알려주고 있다:
 		<<else>>
-			You look across the farm, trying to spot enemy movements:
+			당신은 농장을 가로질러 바라보며, 적의 움직임을 포착하려 노력한다:
 		<</if>>
 		<br>
 		<<set _assault_keys to Object.keys($farm_assault.teams)>>
 		<<for _s to 0; _s lt _assault_keys.length; _s++>>
 			<<if $farm_assault.teams[_assault_keys[_s]].type is "wraith">>
 				<<if $farm_assault.teams[_assault_keys[_s]].location is "done">>
-					<span class="green">The <<farm_assault_thugs>> is walking away, like <<print $wraith.seenFarm ? "it's" : "they've">> lost interest.</span>
+					<span class="green"> <<farm_assault_thugs>> 떠나고 있다. <<print $wraith.seenFarm ? "그것은" : "그들은">> 흥미를 잃은 것 같다.</span> 
 					<<if $wraith.seen gte 5 and !$farm_assault.wraithStress>>
 						<<stress -6>><<lstress>><<set $farm_assault.wraithStress to true>>
 					<</if>>
@@ -620,62 +620,62 @@ You hear shouting outside.
 					<<if _skill gte random(400, 1400) or !$wraith.seenFarm>>
 						<<switch $farm_assault.teams[_assault_keys[_s]].state>>
 						<<case wall>>
-							The <<farm_assault_thugs>> is <span class="purple">walking through the <<print $farm.wall gte 3 ? "fence" : "wall">></span>.
+							<<farm_assault_thugs>> <span class="purple"><<print $farm.wall gte 3 ? "울타리" : "벽">>을 지나고 있다.</span>.
 						<<case entry>>
-							The <<farm_assault_thugs>> is shambling toward <<farm_assault_location>>.
+							<<farm_assault_thugs>> <<farm_assault_location>> 쪽으로 다가가고 있다.
 						<<case field>>
 							<<if $farm_assault.teams[_assault_keys[_s]].field_progress lte 1>>
-								<span class="blue">The <<farm_assault_thugs>> enters <<farm_assault_location>>.</span>
+								<span class="blue"><<farm_assault_thugs>> <<farm_assault_location>>에 들어간다.</span>
 							<<else>>
-								<span class="blue">The <<farm_assault_thugs>> wanders around <<farm_assault_location>>.</span>
+								<span class="blue"><<farm_assault_thugs>> <<farm_assault_location>> 주변을 돌아다니고 있다.</span>
 							<</if>>
 						<<case celebrate>>
-							The <<farm_assault_thugs>> stands completely still. <span class="red"><<farm_assault_location "cap">> bursts into flames.</span>
+							<<farm_assault_thugs>> 가만히 서 있다. <span class="red"><<farm_assault_location "cap">>에 불길이 치솟아 오른다.</span>
 						<</switch>>
 					<<else>>
-						Something seems off at <<farm_assault_location>>.
+						<<farm_assault_location>> 수상하다.
 					<</if>>
 				<</if>>
 			<<else>>
 				<<if $farm_assault.teams[_assault_keys[_s]].location is "done">>
-					<span class="green">The <<farm_assault_no>> group of <<farm_assault_thugs>> are running for the hills.</span>
+					<span class="green"><<farm_assault_no>> <<farm_assault_thugs>> 언덕을 향해 달려가고 있다.</span>
 				<<elseif $farm_assault.teams[_assault_keys[_s]].state is "dogs">>
-					You hear barking from <<farm_assault_location>>.
+					<<farm_assault_location>>에서 짖는 소리가 들린다.
 				<<elseif $farm_assault.teams[_assault_keys[_s]].location is "tower">>
 					<<switch $farm_assault.teams[_assault_keys[_s]].state>>
 					<<case "approach">>
-						<span class="purple">The <<farm_assault_no>> group of <<farm_assault_thugs>> are approaching the watchtower.</span>
+						<span class="purple"><<farm_assault_no>> <<farm_assault_thugs>> 망루에 다가가고 있다.</span>
 					<<case "climb">>
-						<span class="pink">The <<farm_assault_no>> group of <<farm_assault_thugs>> are climbing the watchtower.</span>
+						<span class="pink"><<farm_assault_no>> <<farm_assault_thugs>> 망루를 오르고 있다.</span>
 					<</switch>>
 				<<else>>
 					<<if _skill gte random(1, 1000)>>
 						<<switch $farm_assault.teams[_assault_keys[_s]].state>>
 						<<case wall>>
-							The <<farm_assault_no>> group of <<farm_assault_thugs>> are
+							<<farm_assault_no>> <<farm_assault_thugs>>
 							<<if $farm.wall gte 3>>
-								<span class="pink">cutting through the fence</span> at <<farm_assault_location>>.
+								<<farm_assault_location>>에서 <span class="pink">울타리 사이를 뚫고 있다.</span>
 							<<else>>
-								climbing the wall near <<farm_assault_location>>.
+								<<farm_assault_location>> 근처의 벽을 오르고 있다.
 							<</if>>
 						<<case entry>>
-							The <<farm_assault_no>> group of <<farm_assault_thugs>> are rushing into <<farm_assault_location>>.
+							<<farm_assault_no>> <<farm_assault_thugs>> <<farm_assault_location>>에 들이닥치고 있다.
 						<<case field>>
 						<<switch $farm_assault.teams[_assault_keys[_s]].field_progress>>
 						<<case 0>>
-								<span class="blue">The <<farm_assault_no>> group of <<farm_assault_thugs>> are entering <<farm_assault_location>>.</span>
+								<span class="blue"><<farm_assault_no>> <<farm_assault_thugs>> <<farm_assault_location>>에 들어가고 있다.</span>
 						<<case 1>>
-								<span class="purple">The <<farm_assault_no>> group of <<farm_assault_thugs>> are opening petrol canisters at <<farm_assault_location>>.</span>
+								<span class="purple"><<farm_assault_no>> <<farm_assault_thugs>> <<farm_assault_location>>에서 휘발유 통을 열고 있다.</span>
 						<<case 2>>
-								<span class="pink">The <<farm_assault_no>> group of <<farm_assault_thugs>> are pouring petrol over <<farm_assault_location>>.</span>
+								<span class="pink"><<farm_assault_no>> <<farm_assault_thugs>> <<farm_assault_location>>에 휘발유를 붓고 있다.</span>
 						<<case 3>>
-								<span class="red">The <<farm_assault_no>> group of <<farm_assault_thugs>> are lighting matches at <<farm_assault_location>>.</span>
+								<span class="red"><<farm_assault_no>> <<farm_assault_thugs>> <<farm_assault_location>>에서 성냥에 불을 붙이고 있다.</span>
 						<</switch>>
 						<<case celebrate>>
-							<span class="red">The <<farm_assault_no>> group of <<farm_assault_thugs>> are reveling as the field burns.</span>
+							<span class="red"><<farm_assault_no>> <<farm_assault_thugs>> 밭을 불태우며 환호하고 있다.</span>
 						<</switch>>
 					<<else>>
-						There's movement at <<farm_assault_location>>.
+						<<farm_assault_location>>에 움직임이 있다.
 					<</if>>
 				<</if>>
 			<</if>>
@@ -694,41 +694,41 @@ You hear shouting outside.
 			<<set $farm_assault.alex to "patrol">>
 		<</if>>
 	<<elseif $farm_assault.alex is "patrol">>
-		Your walkie talkie picks up a signal. "I'm looking for intruders," Alex says. "Just checking in."
+		당신의 무전기가 신호를 수신한다. "난 침입자를 찾고 있어," 알렉스가 말한다. "그냥 확인하는 거야."
 	<<else>>
 		<<set _assault_keys to Object.keys($farm_assault.teams)>>
 		<<for _s to 0; _s lt _assault_keys.length; _s++>>
 			<<if $bus is $farm_assault.teams[_assault_keys[_s]].location and $farm_assault.alex is _assault_keys[_s]>>
-				<span class="teal">Alex crouches beside you.</span> "What's the plan?"
+				<span class="teal">알렉스가 당신 옆에 쭈그리고 앉는다.</span> "계획이 뭐야?"
 			<<elseif $farm_assault.alex is _assault_keys[_s]>>
-				Your walkie talkie picks up a signal. "I'm <<print either("pursuing","stalking","following","hunting","harrying")>> <<farm_assault_thugs>> at <<farm_assault_location>>," Alex says in a hushed voice.
+				당신의 무전기가 신호를 수신한다. "나는 <<farm_assault_location>>에서 <<farm_assault_thugs>> <<print either("추적하고","쫓고","따라가고","찾고","공격하고")>> 있어," 알렉스가 조용한 목소리로 말한다.
 				<<if _alex_success>>
 					<<set _rng to random(1, 5)>>
 					<<switch _rng>>
 					<<case 1>>
-						<span class="green">"Knocked one out."</span>
+						<span class="green">"한 놈 나가떨어졌어."</span>
 					<<case 2>>
-						<span class="green">"They'll feel this in the morning."</span>
+						<span class="green">"저놈들은 아침에나 눈치챌 거야."</span>
 					<<case 3>>
-						<span class="green">"Wonder when they'll realise they're missing a colleague."</span>
+						<span class="green">"동료가 없어진 걸 그들이 언제 알아챌지 궁금하네."</span>
 					<<case 4>>
-						<span class="green">"One thug down."</span>
+						<span class="green">"깡패 하나 끝."</span>
 					<<default>>
-						<span class="green">"Took one down."</span>
+						<span class="green">"한 명 쓰러뜨렸어."</span>
 					<</switch>>
 				<<else>>
 					<<set _rng to random(1, 5)>>
 					<<switch _rng>>
 					<<case 1>>
-						<span class="blue">"Can't get them alone."</span>
+						<span class="blue">"그들을 혼자 둘 수는 없어."</span>
 					<<case 2>>
-						<span class="blue">"They're too watchful."</span>
+						<span class="blue">"그들이 너무 조심스러워."</span>
 					<<case 3>>
-						<span class="blue">"Can't get close."</span>
+						<span class="blue">"가까이 갈 수가 없어."</span>
 					<<case 4>>
-						<span class="blue">"Just waiting for my moment."</span>
+						<span class="blue">"적절한 타이밍을 기다리고 있어."</span>
 					<<default>>
-						<span class="blue">"I won't take any risks."</span>
+						<span class="blue">"어떤 위험도 감수하지 않겠어."</span>
 					<</switch>>
 				<</if>>
 			<</if>>
@@ -740,27 +740,27 @@ You hear shouting outside.
 <<widget "farm_assault_location">><<silently>>
 	<<switch $farm_assault.teams[_assault_keys[_s]].location>>
 		<<case 0>>
-			<<set _text_output to "the first field">>
+			<<set _text_output to "첫 번째 밭">>
 		<<case 1>>
-			<<set _text_output to "the second field">>
+			<<set _text_output to "두 번째 밭">>
 		<<case 2>>
-			<<set _text_output to "the third field">>
+			<<set _text_output to "세 번째 밭">>
 		<<case 3>>
-			<<set _text_output to "the fourth field">>
+			<<set _text_output to "네 번째 밭">>
 		<<case 4>>
-			<<set _text_output to "the fifth field">>
+			<<set _text_output to "다섯 번째 밭">>
 		<<case 5>>
-			<<set _text_output to "the sixth field">>
+			<<set _text_output to "여섯 번째 밭">>
 		<<case 6>>
-			<<set _text_output to "the seventh field">>
+			<<set _text_output to "일곱 번째 밭">>
 		<<case 7>>
-			<<set _text_output to "the eighth field">>
+			<<set _text_output to "여덟 번째 밭">>
 		<<case 8>>
-			<<set _text_output to "the ninth field">>
+			<<set _text_output to "아홉 번째 밭">>
 		<<case tower>>
-			<<set _text_output to "the watchtower">>
+			<<set _text_output to "망루">>
 		<<default>>
-			<<set _text_output to "the fields">>
+			<<set _text_output to "들판">>
 	<</switch>>
 	<<if _args[0] is "cap">>
 		<<capitalise>>
@@ -770,15 +770,15 @@ You hear shouting outside.
 <<widget "farm_assault_thugs">><<silently>>
 	<<switch $farm_assault.teams[_assault_keys[_s]].type>>
 		<<case "bailey">>
-			<<set _text_output to "<span class=\"red\">Bailey's thugs</span>">>
+			<<set _text_output to "<span class=\"red\">베일리의 깡패들</span>">>
 		<<case "wraith">>
 			<<if $wraith.seenFarm>>
-				<<set _text_output to "<span class=\"wraith\">pale figure</span>">>
+				<<set _text_output to "<span class=\"wraith\">창백한 형체</span>">>
 			<<else>>
-				<<set _text_output to "<span class=\"black\">shifty stranger</span>">>
+				<<set _text_output to "<span class=\"black\">수상한 낯선 이</span>">>
 			<</if>>
 		<<default>>
-			<<set _text_output to "<span class=\"pink\">Remy's thugs</span>">>
+			<<set _text_output to "<span class=\"pink\">레미의 깡패들</span>">>
 	<</switch>>
 	<<if _args[0] is "cap">>
 		<<capitalise>>
@@ -790,47 +790,47 @@ You hear shouting outside.
 		<<link [[기다린다 (0:05)|Farm Assault]]>><<pass 5>><<set $farm_assault.movement to "wait">><</link>>
 		<br>
 		<<if $bus is "tower" and _tower isnot "threatened" and $farm_assault.tower isnot "manned">>
-			<<link [[Climb the watchtower (0:05)|Farm Assault]]>><<pass 5>><<set $bus to "tower_top">><<set $farm_assault.movement to "climb">><</link>>
+			<<link [[망루에 올라간다 (0:05)|Farm Assault]]>><<pass 5>><<set $bus to "tower_top">><<set $farm_assault.movement to "climb">><</link>>
 			<br>
 		<</if>>
 		<<if $bus isnot 0>>
-			<<link [[First field (0:05)|Farm Assault]]>><<pass 5>><<set $bus to 0>><<set $farm_assault.movement to "field">><</link>>
+			<<link [[첫 번째 밭 (0:05)|Farm Assault]]>><<pass 5>><<set $bus to 0>><<set $farm_assault.movement to "field">><</link>>
 			<br>
 		<</if>>
 		<<if $bus isnot 1>>
-			<<link [[Second field (0:05)|Farm Assault]]>><<pass 5>><<set $bus to 1>><<set $farm_assault.movement to "field">><</link>>
+			<<link [[두 번째 밭 (0:05)|Farm Assault]]>><<pass 5>><<set $bus to 1>><<set $farm_assault.movement to "field">><</link>>
 			<br>
 		<</if>>
 		<<if $bus isnot 2>>
-			<<link [[Third field (0:05)|Farm Assault]]>><<pass 5>><<set $bus to 2>><<set $farm_assault.movement to "field">><</link>>
+			<<link [[세 번째 밭 (0:05)|Farm Assault]]>><<pass 5>><<set $bus to 2>><<set $farm_assault.movement to "field">><</link>>
 			<br>
 		<</if>>
 		<<if $bus isnot 3>>
-			<<link [[Fourth field (0:05)|Farm Assault]]>><<pass 5>><<set $bus to 3>><<set $farm_assault.movement to "field">><</link>>
+			<<link [[네 번째 밭 (0:05)|Farm Assault]]>><<pass 5>><<set $bus to 3>><<set $farm_assault.movement to "field">><</link>>
 			<br>
 		<</if>>
 		<<if $bus isnot 4 and $farm_stage gte 8>>
-			<<link [[Fifth field (0:05)|Farm Assault]]>><<pass 5>><<set $bus to 4>><<set $farm_assault.movement to "field">><</link>>
+			<<link [[다섯 번째 밭 (0:05)|Farm Assault]]>><<pass 5>><<set $bus to 4>><<set $farm_assault.movement to "field">><</link>>
 			<br>
 		<</if>>
 		<<if $bus isnot 5 and $farm_stage gte 9>>
-			<<link [[Sixth field (0:05)|Farm Assault]]>><<pass 5>><<set $bus to 5>><<set $farm_assault.movement to "field">><</link>>
+			<<link [[여섯 번째 밭 (0:05)|Farm Assault]]>><<pass 5>><<set $bus to 5>><<set $farm_assault.movement to "field">><</link>>
 			<br>
 		<</if>>
 		<<if $bus isnot 6 and $farm_stage gte 10>>
-			<<link [[Seventh field (0:05)|Farm Assault]]>><<pass 5>><<set $bus to 6>><<set $farm_assault.movement to "field">><</link>>
+			<<link [[일곱 번째 밭 (0:05)|Farm Assault]]>><<pass 5>><<set $bus to 6>><<set $farm_assault.movement to "field">><</link>>
 			<br>
 		<</if>>
 		<<if $bus isnot 7 and $farm_stage gte 11>>
-			<<link [[Eighth field (0:05)|Farm Assault]]>><<pass 5>><<set $bus to 7>><<set $farm_assault.movement to "field">><</link>>
+			<<link [[여덟 번째 밭 (0:05)|Farm Assault]]>><<pass 5>><<set $bus to 7>><<set $farm_assault.movement to "field">><</link>>
 			<br>
 		<</if>>
 		<<if $bus isnot 8 and $farm_stage gte 12>>
-			<<link [[Ninth field (0:05)|Farm Assault]]>><<pass 5>><<set $bus to 8>><<set $farm_assault.movement to "field">><</link>>
+			<<link [[아홉 번째 밭 (0:05)|Farm Assault]]>><<pass 5>><<set $bus to 8>><<set $farm_assault.movement to "field">><</link>>
 			<br>
 		<</if>>
 		<<if $bus isnot "tower" and $bus isnot "tower_top" and $farm.tower gte 1>>
-			<<link [[Watchtower (0:05)|Farm Assault]]>><<pass 5>><<set $bus to "tower">><<set $farm_assault.movement to "tower">><</link>>
+			<<link [[망루 (0:05)|Farm Assault]]>><<pass 5>><<set $bus to "tower">><<set $farm_assault.movement to "tower">><</link>>
 			<br>
 		<</if>>
 	<</if>>
@@ -839,32 +839,32 @@ You hear shouting outside.
 <<widget "farm_assault_actions">>
 	<<switch $bus>>
 		<<case "tower">>
-			The watchtower looms above you.
+			망루가 당신 위에 있다.
 		<<case 0>>
-			You are near the first field.
+			당신은 첫 번째 밭 근처에 있다.
 		<<case 1>>
-			You are near the second field.
+			당신은 두 번째 밭 근처에 있다.
 		<<case 2>>
-			You are near the third field.
+			당신은 세 번째 밭 근처에 있다.
 		<<case 3>>
-			You are near the fourth field.
+			당신은 네 번째 밭 근처에 있다.
 		<<case 4>>
-			You are near the fifth field.
+			당신은 다섯 번째 밭 근처에 있다.
 		<<case 5>>
-			You are near the sixth field.
+			당신은 여섯 번째 밭 근처에 있다.
 		<<case 6>>
-			You are near the seventh field.
+			당신은 일곱 번째 밭 근처에 있다.
 		<<case 7>>
-			You are near the eighth field.
+			당신은 여덟 번째 밭 근처에 있다.
 		<<case 8>>
-			You are near the ninth field.
+			당신은 아홉 번째 밭 근처에 있다.
 	<</switch>>
 	<br>
 	<<if $farm_assault.bindings gte 1>>
-		You lie in the dirt, unable to move much.
+		당신은 흙 위에 누워 있다. 제대로 움직일 수 없다.
 		<br><br>
 
-		<<link [[Struggle (0:05)|Farm Assault]]>><<pass 5>><<set $farm_assault.bindings -= 1>><<set $farm_assault.movement to "struggle">><</link>>
+		<<link [[몸부림친다 (0:05)|Farm Assault]]>><<pass 5>><<set $farm_assault.bindings -= 1>><<set $farm_assault.movement to "struggle">><</link>>
 		<br>
 	<<else>>
 		<<set _assault_keys to Object.keys($farm_assault.teams)>>
@@ -876,85 +876,85 @@ You hear shouting outside.
 			<<if $bus is $_team.location>>
 				<<if $bus is "tower">>
 					<<if $_team.state is "approach">>
-						<span class="blue"><<farm_assault_thugs>> approach.</span>
+						<span class="blue"><<farm_assault_thugs>> 다가온다.</span>
 						<br><br>
 						<<farm_assault_attack_options>>
 					<<elseif $_team.state is "climb">>
-						<span class="purple">You see <<farm_assault_thugs>> entering the tower.</span>
+						<span class="purple">당신은 <<farm_assault_thugs>> 망루에 들어가는 것을 본다.</span>
 						<br><br>
 
-						<<link [[Defend the watchtower (0:05)|Farm Assault Tower Defend]]>><<pass 5>><</link>>
+						<<link [[망루를 방어한다 (0:05)|Farm Assault Tower Defend]]>><<pass 5>><</link>>
 						<br>
 					<<elseif $_team.state is "fight">>
-						<span class="pink">You hear $farm.tower_guard fighting <<farm_assault_thugs>> at the top of the tower!</span>
+						<span class="pink">당신은 망루 꼭대기에서 <<NPCname_ ga $farm.tower_guard>> <<farm_assault_thugs>> 싸우는 소리를 듣는다!</span>
 						<br><br>
 
-						<<link [[Defend the watchtower (0:05)|Farm Assault Tower Defend]]>><<pass 5>><</link>>
+						<<link [[망루를 방어한다 (0:05)|Farm Assault Tower Defend]]>><<pass 5>><</link>>
 						<br>
 					<</if>>
 				<<elseif $_team.state is "wall">>
 					<<if $_isWraith>>
-						You see the <<farm_assault_thugs>> <span class="pink">walking through the <<print $farm.wall gte 3 ? "fence" : "wall">></span>.
+						당신은 <<farm_assault_thugs>> <span class="pink"><<print $farm.wall gte 3 ? "울타리" : "벽">>을 지나고 있는 것을 발견한다.</span>.
 					<<else>>
 						<<if $farm.wall gte 3>>
-							You see <<farm_assault_thugs>> sawing through the fence.
+							당신은 <<farm_assault_thugs>> 울타리를 톱질하는 것을 발견한다.
 						<<else>>
-							You see <<farm_assault_thugs>> climbing over the wall.
+							당신은 <<farm_assault_thugs>> 벽을 오르는 것을 발견한다.
 						<</if>>
 						<<if $_team.number is 1>>
-							There's only one here.
+							여기엔 한 명밖에 없다.
 						<<else>>
-							There are <<number $_team.number>> of them.
+							그들은 <<trNumber $_team.number>> 명이다.
 						<</if>>
 					<</if>>
 					<<if $_isBaileyTeam>>
-						<span class="red">They move with surety.</span>
+						<span class="red">그들은 확신을 가지고 움직인다.</span>
 					<</if>>
 					<br>
 					<<if $farm_assault.alex is $_key>>
-						<<link [[Throw rocks with Alex (0:05)|Farm Assault Rocks Alex]]>><<pass 5>><</link>>
+						<<link [[알렉스와 돌을 던진다 (0:05)|Farm Assault Rocks Alex]]>><<pass 5>><</link>>
 						<br>
 					<<else>>
 						<<set $_min to ($_isBaileyTeam ? 6000 : 1)>>
 						<<set $_max to ($_isBaileyTeam ? 20000 : 16000)>>
-						<<link [[Throw rocks (0:05)|Farm Assault Rocks]]>><<pass 5>><</link>><<physiquedifficulty $_min $_max>>
+						<<link [[돌을 던진다 (0:05)|Farm Assault Rocks]]>><<pass 5>><</link>><<physiquedifficulty $_min $_max>>
 						<br>
 					<</if>>
 					<<set $_min to ($_isBaileyTeam ? 3000 : 200)>>
 					<<set $_max to ($_isBaileyTeam ? 3000 : 1000)>>
-					<<link [[Threaten (0:05)|Farm Assault Threaten]]>><<pass 5>><</link>><<skill_difficulty "$fame.scrap" "Combat Fame" $_min $_max>>
+					<<link [[위협한다 (0:05)|Farm Assault Threaten]]>><<pass 5>><</link>><<skill_difficulty "$fame.scrap" "전투 명성" $_min $_max>>
 					<br>
 				<<elseif $_team.state is "entry">>
 					<<if $_isBaileyTeam>>
 						<<if $_team.number gte 2>>
-							You see <<number $_team.number>> of <<farm_assault_thugs>> rush into the farm. They ignore you, instead heading into the fields.
+							당신은 <<farm_assault_thugs>> 중 <<trNumber $_team.number>> 명이 농장으로 뛰어들어가는 것을 발견한다. 그들은 당신을 무시하고 들판으로 향한다.
 							<br>
 							<<farm_assault_attack_options>>
 						<<else>>
-							You see one of <<farm_assault_thugs>> rush into the farm.
+							당신은 <<farm_assault_thugs>> 중 하나가 농장으로 뛰어들어가는 것을 발견한다.
 							<br>
 							<<farm_assault_attack_options>>
 						<</if>>
 					<<elseif $_isWraith>>
 						<<set _noOptions to true>>
-						You see the <<farm_assault_thugs>> approach you.
+						당신은 <<farm_assault_thugs>> 당신에게 다가오는 것을 발견한다.
 						<<if !$wraithIntro>>
 							<<set $wraithIntro to true>>
-							They're a beautiful pale figure, wearing translucent white robes. They regard you with angry red eyes, clutching at their own neck.
+							그들은 반투명한 흰 예복을 입은, 아름다운 창백한 형체다. 그들은 자신의 목을 움켜쥔 채, 분노로 가득 찬 붉은 눈으로 당신을 응시한다.
 						<<elseif !$wraith.seenFarm>>
-							<span class="red">Their face is a terrible, familiar pale.</span>
+							<span class="red">그들의 얼굴은 끔찍하고, 창백한 안색이 낯이 익다.</span>
 						<<else>>
-							It smiles a terrible, familiar smile.
+							그것은 소름끼치는, 익숙한 미소를 짓는다.
 						<</if>>
-						A bizarre, slimy substance leaks wherever they walk.
+						그들이 걷는 곳마다 기괴하고 끈적거리는 물질이 새어나온다.
 						<<set $wraith.seenFarm to true>>
 						<br><br>
 
-						"<span class="wraith">Drown in smoke. Drown in flame.</span>"
+						"<span class="wraith">연기에 빠져 죽어. 불꽃에 빠져 죽어.</span>"
 						<br><br>
 
 						<<if $farm_assault.alex is $_key>>
-							"I'm doubling back," Alex whispers, <span class="red">seemingly not noticing the pale figure. <<nnpc_He "Alex">> creeps away.</span>
+							"난 왔던 길로 돌아갈게," <span class="red">창백한 형체를 눈치채지 못한 듯이, 알렉스가 속삭인다. <<nnpc_He_ ga "Alex">> 살금살금 멀어진다.</span>
 							<<set $farm_assault.alex to "patrol">>
 							<br><br>
 						<</if>>
@@ -966,19 +966,19 @@ You hear shouting outside.
 						<<link [[다음|Farm Assault Wraith Fight]]>><<set $fightstart to 1>><</link>>
 					<<else>>
 						<<if $_team.number gte 2>>
-							You see <<number $_team.number>> of <<farm_assault_thugs>> rush into the farm. They ignore you, instead heading into the fields.
+							당신은 <<farm_assault_thugs>> 중 <<trNumber $_team.number>> 명이 농장으로 뛰어들어가는 것을 발견한다. 그들은 당신을 무시하고 들판으로 향한다.
 							<br><br>
 
 							<<farm_assault_attack_options>>
 						<<else>>
-							You see one of <<farm_assault_thugs>> rush into the farm.
+							당신은 <<farm_assault_thugs>> 중 하나가 농장으로 뛰어들어가는 것을 발견한다.
 							<br><br>
 
 							<<farm_assault_attack_options>>
 						<</if>>
 					<</if>>
 				<<elseif $_team.state is "dogs">>
-					<span class="green">Your <<farm_text_many dog>> emerge from the dark, and set upon <<farm_assault_thugs>>!</span>
+					<span class="green">어둠 속에서 당신의 <<farm_text_many_ ga dog>> 나타나, <<farm_assault_thugs>>에게 달려든다!</span>
 					<br><br>
 				<<elseif $_team.state is "dogs_recover">>
 					<<if $_isBaileyTeam>>
@@ -1026,21 +1026,21 @@ You hear shouting outside.
 					<<farm_assault_attack_options>>
 				<<elseif $_team.state is "field">>
 					<<if $_isWraith>>
-						You see the <<farm_assault_thugs>> wandering in the field.
+						당신은 <<farm_assault_thugs>> 들판을 돌아다니는 것을 발견한다.
 						<<if !$wraith.seenFarm>>
-							They don't look like they're doing anything.
+							그들은 아무것도 하지 않는 것처럼 보인다.
 						<<else>>
-							<span class="purple">You suspect it's spreading flammable slime.</span>
+							<span class="purple">당신은 그것이 인화성 슬라임을 퍼뜨리려는 게 아닌지 의심한다.</span>
 						<</if>>
 					<<else>>
 						<<if $_team.field_progress gte 4>>
-							<span class="pink">You see <<farm_assault_thugs>> lighting matches!</span>
+							<span class="pink">당신은 <<farm_assault_thugs>> 성냥에 불을 붙이는 것을 발견한다!</span>
 						<<elseif $_team.field_progress gte 3>>
-							<span class="purple">You see <<farm_assault_thugs>> covering the field in petrol.</span>
+							<span class="purple">당신은 <<farm_assault_thugs>> 들판에 휘발유를 붓고 있는 것을 발견한다.</span>
 						<<elseif $_team.field_progress gte 2>>
-							<span class="blue">You see <<farm_assault_thugs>> opening petrol canisters.</span>
+							<span class="blue">당신은 <<farm_assault_thugs>> 휘발유 통을 열고 있는 것을 발견한다.</span>
 						<<else>>
-							<span class="lblue">You see <<farm_assault_thugs>> prowling through the field.</span>
+							<span class="lblue">당신은 <<farm_assault_thugs>> 들판을 배회하는 것을 발견한다.</span>
 						<</if>>
 					<</if>>
 					<br>
@@ -1057,28 +1057,28 @@ You hear shouting outside.
 
 <<widget "farm_assault_intruders">>
 	<<if $farm_assault.teams[_assault_keys[_s]].number gte 2>>
-		<<set _text_output to "intruders">>
+		<<set _text_output to "침입자들">>
 	<<else>>
-		<<set _text_output to "intruder">>
+		<<set _text_output to "침입자">>
 	<</if>>
 	<<print _text_output>>
 <</widget>>
 
 <<widget "farm_assault_no">>
 	<<if $farm_assault.teams[_assault_keys[_s]].type is "bailey">>
-		vicious
+		악랄한
 	<<else>>
 		<<switch _s>>
 		<<case 0>>
-			first
+			첫 번째
 		<<case 1>>
-			second
+			두 번째
 		<<case 2>>
-			third
+			세 번째
 		<<case 3>>
-			fourth
+			네 번째
 		<<case 4>>
-			fifth
+			다섯 번째
 		<</switch>>
 	<</if>>
 <</widget>>
@@ -1096,34 +1096,34 @@ You hear shouting outside.
 <<widget "farm_assault_attack_options">>
 	<<if $farm_assault.alex is _assault_keys[_s]>>
 		<<if $farm_assault.teams[_assault_keys[_s]].number gte 2>>
-			<<link [[Work with Alex to pick one off (0:05)|Farm Assault Pick Alex]]>><<pass 5>><</link>>
+			<<link [[알렉스와 협동하여 한 명을 쓰러뜨린다 (0:05)|Farm Assault Pick Alex]]>><<pass 5>><</link>>
 			<br>
 			<<if $pain gte 100>>
-				<span class="red">You are in too much pain to fight them head on.</span>
+				<span class="red">당신은 그들에게 정면으로 맞서기에는 너무 고통스럽다.</span>
 			<<else>>
-				<<link [[Charge with Alex (0:05)|Farm Assault Charge]]>><<pass 5>><</link>>
+				<<link [[알렉스와 함께 달려든다 (0:05)|Farm Assault Charge]]>><<pass 5>><</link>>
 			<</if>>
 		<<elseif $farm_assault.teams[_assault_keys[_s]].number gte 1 and $farm_assault.teams[_assault_keys[_s]].location isnot "done" and $farm_assault.teams[_assault_keys[_s]].state isnot "dogs_recover">>
-			The intruder is alone.
+			침입자는 혼자다.
 			<br><br>
-			<<link [[Overpower|Farm Assault Overpower]]>><</link>>
+			<<link [[제압한다|Farm Assault Overpower]]>><</link>>
 		<</if>>
 	<<elseif $pain gte 100>>
-		<span class="red">You're in too much pain to fight them head-on.</span>
+		<span class="red">당신은 그들에게 정면으로 맞서기에는 너무 고통스럽다.</span>
 	<<else>>
 		<<if $farm_assault.teams[_assault_keys[_s]].type is "bailey">>
-			<<link [[Fight them head-on (0:05)|Farm Assault Intercept Bailey]]>><<pass 5>><</link>>
+			<<link [[정면으로 맞선다 (0:05)|Farm Assault Intercept Bailey]]>><<pass 5>><</link>>
 			<br>
 			<<set $skulduggerydifficulty to 1000>>
-			<<link [[Pick one off (0:05)|Farm Assault Pick Bailey]]>><<pass 5>><</link>><<skulduggerydifficulty>>
+			<<link [[한 명을 쓰러뜨린다 (0:05)|Farm Assault Pick Bailey]]>><<pass 5>><</link>><<skulduggerydifficulty>>
 		<<elseif $farm_assault.teams[_assault_keys[_s]].type is "wraith">>
-			<<set $_them to $wraith.seenFarm ? "it" : "them">>
-			<<link [["Fight " + $_them + " head on"|Farm Assault Intercept Wraith]]>><</link>>
+			<<set $_them to $wraith.seenFarm ? "그것" : "그들">>
+			<<link [[$_them + "에 정면으로 맞선다"|Farm Assault Intercept Wraith]]>><</link>>
 		<<else>>
-			<<link [[Fight them head-on (0:05)|Farm Assault Intercept]]>><<pass 5>><</link>>
+			<<link [[정면으로 맞선다 (0:05)|Farm Assault Intercept]]>><<pass 5>><</link>>
 			<br>
 			<<set $skulduggerydifficulty to 600>>
-			<<link [[Pick one off (0:05)|Farm Assault Pick]]>><<pass 5>><</link>><<skulduggerydifficulty>>
+			<<link [[한 명을 쓰러뜨린다 (0:05)|Farm Assault Pick]]>><<pass 5>><</link>><<skulduggerydifficulty>>
 		<</if>>
 	<</if>>
 	<br>
@@ -1137,12 +1137,12 @@ You hear shouting outside.
 	<<if $bus is $farm_assault.teams[_assault_keys[_s]].location>>
 		<<if $physiqueSuccess>>
 			<<generate1>><<person1>>
-			You and Alex pelt the <<farm_assault_intruders>> from the shadows. Most miss, <span class="green">but one lands true</span>, hitting the <<person>> right on the noggin. <<He>> tumbles away from the <<farm_fence>>.
+			당신과 알렉스는 어둠 속에서 <<farm_assault_intruders>> 공격한다. 대부분 빗나가지만 <span class="green">하나가 올바르게 날아가</span>, <<person_ ui>> 머리 오른쪽을 강타한다. <<He_ nun>> <<farm_fence>>에서 굴러 떨어진다.
 			<br><br>
 			<<set $farm_assault.teams[_assault_keys[_s]].number -= 1>>
 		<<else>>
 			<<generate1>><<person1>>
-			You pelt the <<farm_assault_intruders>> from the shadows. They've chosen a sheltered spot to break in, shielded by earth from most angles, and trees by others. <span class="red">You fail to hit any.</span>
+			당신은 어둠 속에서 <<farm_assault_intruders>> 공격한다. 그들은 땅이나 나무들로 가려진 은신처에 몸을 숨긴다. <span class="red">당신은 누구도 맞추지 못했다.</span>
 			<br><br>
 		<</if>>
 	<</if>>
@@ -1159,11 +1159,11 @@ You hear shouting outside.
 	<<if $bus is $farm_assault.teams[_assault_keys[_s]].location>>
 		<<if $farm_assault.teams[_assault_keys[_s]].type is "bailey" and random(1, 2) is 2>>
 			<<generate1>><<person1>>
-			You and Alex pelt the <<farm_assault_intruders>> from the shadows. They've chosen a sheltered spot to break in, shielded by earth from most angles, and trees by the others. <span class="red">You fail to hit any.</span>
+			당신과 알렉스는 어둠 속에서 <<farm_assault_intruders>> 공격한다. 그들은 땅이나 나무들로 가려진 은신처에 몸을 숨긴다. <span class="red">당신은 누구도 맞추지 못했다.</span>
 			<br><br>
 		<<else>>
 			<<generate1>><<person1>>
-			You and Alex pelt the <<farm_assault_intruders>> from the shadows. Most miss, <span class="green">but one lands true</span>, hitting the <<person>> right on the noggin. <<He>> tumbles away from the <<farm_fence>>.
+			당신과 알렉스는 어둠 속에서 <<farm_assault_intruders>> 공격한다. 대부분 빗나가지만 <span class="green">하나가 올바르게 날아가</span>, <<person_ ui>> 머리 오른쪽을 강타한다. <<He_ nun>> <<farm_fence>>에서 굴러 떨어진다.
 			<br><br>
 			<<set $farm_assault.teams[_assault_keys[_s]].number -= 1>>
 		<</if>>
@@ -1176,13 +1176,13 @@ You hear shouting outside.
 :: Farm Assault Threaten
 <<effects>>
 
-You march into the open.
+당신은 당당하게 걸어 나온다.
 <<if $speech_attitude is "meek">>
-	"I-I won't be bullied," you say. "Stop this at once, or you'll be sorry."
+	"나-나는 괴롭힘당하지 않겠어," 당신이 말한다. "당장 그만둬, 그렇지 않으면 후회할 거야."
 <<elseif $speech_attitude is "bratty">>
-	"Get the fuck off my property," you say. "Before I feed you to the pigs."
+	"내 땅에서 꺼져," 당신이 말한다. "너희들을 돼지 밥으로 만들기 전에."
 <<else>>
-	"If you leave now," you say. "I won't follow."
+	"지금 떠나면," 당신이 말한다. "뒤따라가지 않을게."
 <</if>>
 <br><br>
 <<set _assault_keys to Object.keys($farm_assault.teams)>>
@@ -1191,39 +1191,39 @@ You march into the open.
 		<<if $farm_assault.teams[_assault_keys[_s]].type is "bailey">>
 			<<if $farm_assault.teams[_assault_keys[_s]].number gte 2>>
 				<<generate1>><<person1>>
-				<span class="red">The intruders laugh.</span>
+				<span class="red">침입자들이 웃는다.</span>
 				<<if $fame.scrap gte 400>>
-					"<span class="pink"><<underworld_nickname>></span>," a <<person>> says. "Very scary. But there's scarier behind us."
+					"<span class="pink"><<underworld_nicknamePost>></span>," <<person_ i>> 말한다. "무서워라. 그런데 우리 뒤에는 훨씬 무서운 게 있거든."
 				<<else>>
-					"Very scary," a <<person>> says. "But there's scarier behind us."
+					"무서워라," <<person_ i>> 말한다. "그런데 우리 뒤에는 훨씬 무서운 게 있거든."
 				<</if>>
-				They continue forcing their way in.
+				그들은 계속해서 강제로 진입한다.
 			<<else>>
 				<<generate1>><<person1>>
-				<span class="red">The <<person>> laughs.</span>
+				<span class="red"><<person_ i>> 웃는다.</span>
 				<<if $fame.scrap gte 400>>
-					"<span class="pink"><<underworld_nickname>></span>," <<he>> says. "Very scary. But there's scarier behind me."
+					"<span class="pink"><<underworld_nicknamePost>></span>," <<he_ ga>> 말한다. "무서워라. 그런데 내 뒤에는 훨씬 무서운 게 있거든."
 				<<else>>
-					"Very scary," <<he>> says. "But there's scarier behind me."
+					"무서워라," <<he_ ga>> 말한다. "그런데 내 뒤에는 훨씬 무서운 게 있거든."
 				<</if>>
-				<<He>> continues forcing their way in.
+				<<He_ nun>> 계속해서 강제로 진입한다.
 			<</if>>
 		<<elseif $fame.scrap gte random(200, 1000)>>
 			<<if $farm_assault.teams[_assault_keys[_s]].number gte 2>>
 				<<generate1>><<person1>><<generate2>>
-				The intruders glance at each other.
+				침입자들이 서로를 흘깃거린다.
 				<br>
-				"Is that the one they call <span class="pink"><<underworld_nickname>></span>?" a <<person>> asks.
+				"쟤가 그들이 <span class="pink"><<underworld_nicknamePost "라고">></span> 부르는 애야?" <<person_ i>> 묻는다.
 				<br>
-				"Aye. That's why we're paid so well," a <<person2>><<person>> responds.
+				"그래. 그래서 우리가 보수를 많이 받는 거지," <<person2>><<person_ i>> 대답한다.
 				<br>
-				"I'm not getting paid to get my shit kicked in. I'm out." <span class="green">They turn and run.</span>
+				"난 처맞으려고 돈 받은 게 아니야. 난 빠지겠어." <span class="green">그들은 뒤돌아 달려간다.</span>
 				<br><br>
 
 				<<set $farm_assault.teams[_assault_keys[_s]].location to "done">>
 			<<else>>
 				<<generate1>><<person1>>
-				The intruder, a <<person>>, stares at you. "I'm just getting paid to clear some fields," <<he>> says. "I don't want no trouble." <span class="green"><<He>> turns and leaves.</span>
+				침입자, <<person_ i>> 당신을 바라본다. "나는 밭을 좀 청소하는 대가로 돈을 받았을 뿐이야," <<he_ ga>> 말한다. "문제를 일으킬 생각은 없어." <span class="green"><<He_ nun>> 뒤돌아 떠난다.</span>
 				<br><br>
 
 				<<set $farm_assault.teams[_assault_keys[_s]].location to "done">>
@@ -1231,13 +1231,13 @@ You march into the open.
 		<<else>>
 			<<if $farm_assault.teams[_assault_keys[_s]].number gte 2>>
 				<<generate1>><<person1>><<generate2>>
-				The intruders glance at each other, <span class="red">and laugh.</span> "This <<girl>> thinks <<pshes>> tough or something," a <<person>> says. "About to learn a hard lesson."
+				침입자들이 서로를 흘깃거리다가, <span class="red">웃는다.</span> "이 <<girl_ un>> <<pshes_ ga>> 터프하다고 생각하나 봐," <<person_ i>> 말한다. "곧 가혹한 교훈을 얻게 되겠군."
 				<br><br>
-				They continue forcing their way in.
+				그들은 계속해서 강제로 진입한다.
 				<br><br>
 			<<else>>
 				<<generate1>><<person1>>
-				<span class="red">The intruder laughs.</span> "Who do you think you are?" <<he>> says. "Some <<girl>> is all I see, about to learn a hard lesson." <<He>> continues to enter.
+				<span class="red">침입자가 웃는다.</span> "네가 뭔데?" <<he_ ga>> 말한다. "내 눈에 보이는 건 곧 가혹한 교훈을 얻게 될 <<girl>>뿐인데." <<He_ nun>> 계속해서 들어온다.
 				<br><br>
 			<</if>>
 		<</if>>
@@ -1257,15 +1257,15 @@ You march into the open.
 	<<if $bus is $farm_assault.teams[_assault_keys[_s]].location>>
 		<<if $farm_assault.teams[_assault_keys[_s]].number gte 3>>
 			<<generate1>><<generate2>><<generate3>>
-			You charge Remy's thugs, a <<fullGroup>>. They plant their feet, ready to face you.
+			당신은 레미의 깡패들, <<fullGroupPost>>에게 달려든다. 그들은 발을 단단히 디디며 맞설 준비를 한다.
 			<br><br>
 		<<elseif $farm_assault.teams[_assault_keys[_s]].number gte 2>>
 			<<generate1>><<generate2>>
-			You charge Remy's thugs, a <<fullGroup>>. They plant their feet, ready to face you.
+			당신은 레미의 깡패들, <<fullGroupPost>>에게 달려든다. 그들은 발을 단단히 디디며 맞설 준비를 한다.
 			<br><br>
 		<<else>>
 			<<generate1>>
-			You charge Remy's thug, a <<person1>><<person>>. <<He>> seems startled by your boldness, but plants <<his>> feet as you approach.
+			당신은 레미의 깡패, <<person1>><<personPost>>에게 달려든다. <<He_ nun>> 당신의 대담함에 놀란 듯 보였지만, 당신이 가까워지자 발을 단단히 딛는다.
 			<br><br>
 		<</if>>
 	<</if>>
@@ -1283,15 +1283,15 @@ You march into the open.
 	<<if $bus is $farm_assault.teams[_assault_keys[_s]].location>>
 		<<if $farm_assault.teams[_assault_keys[_s]].number gte 3>>
 			<<generate1>><<generate2>><<generate3>>
-			You charge Bailey's thugs, a <<fullGroup>>. They turn to meet you. The <<person1>><<person>> cracks <<his>> knuckles.
+			당신은 베일리의 깡패들, <<fullGroupPost>>에게 달려든다. 그들은 당신에게 맞서기 위해 돌아선다. <<person1>><<person_ i>> <<his_ yi>> 손마디를 꺾는다.
 			<br><br>
 		<<elseif $farm_assault.teams[_assault_keys[_s]].number gte 2>>
 			<<generate1>><<generate2>>
-			You charge Bailey's thugs, a <<fullGroup>>. They turn to meet you. The <<person1>><<person>> cracks <<his>> knuckles.
+			당신은 베일리의 깡패들, <<fullGroupPost>>에게 달려든다. 그들은 당신에게 맞서기 위해 돌아선다. <<person1>><<person_ i>> <<his_ yi>> 손마디를 꺾는다.
 			<br><br>
 		<<else>>
 			<<generate1>>
-			You charge Bailey's thug, a <<person1>><<person>>. <<He>> turns to meet you, and cracks <<his>> knuckles.
+			당신은 베일리의 깡패, <<fullGroupPost>>에게 달려든다. <<He_ nun>> 당신에게 맞서기 위해 돌아서며, <<his_ yi>> 손마디를 꺾는다.
 			<br><br>
 		<</if>>
 	<</if>>
@@ -1331,12 +1331,12 @@ You march into the open.
 <<if $enemyarousal gte $enemyarousalmax>>
 	<<ejaculation>>
 	<<if $enemynomax gte 2>>
-		Remy's thugs are too dazed and exhausted to continue, <span class="green">and stagger from the field.</span>
+		레미의 깡패들은 진이 빠지고 멍해진 채로, <span class="green">비틀거리며 들판을 빠져나간다.</span>
 	<<else>>
-		The <<person1>><<person>> is too dazed and exhausted to continue, <span class="green">and staggers from the field.</span>
+		<<person1>><<person_ un>> 진이 빠지고 멍해진 채로, <span class="green">비틀거리며 들판을 빠져나간다.</span>
 	<</if>>
 	<br><br>
-	<<tearful>> you plan your next move.
+	<<tearful>> 당신은 다음 행동을 계획한다.
 	<br><br>
 	<<clotheson>>
 	<<endcombat>>
@@ -1350,12 +1350,12 @@ You march into the open.
 	<</for>>
 <<elseif $enemyhealth lte 0>>
 	<<if $enemynomax gte 2>>
-		<span class="green">Remy's thugs flee the field,</span> throwing worried glances over their shoulders to make sure you're not pursuing.
+		<span class="green">레미의 깡패들이 들판을 달아난다.</span> 그들은 당신이 쫓아올까 봐, 어깨 너머로 걱정스러운 눈빛을 던진다.
 	<<else>>
-		<span class="green">The <<person1>><<person>> flees the field,</span> throwing worried glances over <<his>> shoulder to make sure you're not pursing.
+		<span class="green"><<person1>><<person_ i>> 들판을 달아난다.</span> <<He_ nun>> 당신이 쫓아올까 봐, 어깨 너머로 걱정스러운 눈빛을 던진다.
 	<</if>>
 	<br><br>
-	<<tearful>> you plan your next move.
+	<<tearful>> 당신은 다음 행동을 계획한다.
 	<br><br>
 	<<clotheson>>
 	<<endcombat>>
@@ -1369,13 +1369,13 @@ You march into the open.
 	<</for>>
 
 <<else>>
-	You fall to the earth, too hurt to continue fighting.
+	당신은 땅에 쓰러진다. 너무 고통스러워서 더는 싸울 수 없다.
 	<br><br>
-	The <<person1>><<person>> crouches over you, <span class="purple">and gropes your <<breasts>></span>. "Shame I got a job to do," <<he>> says.
+	<<person1>><<person_ i>> 당신 위로 몸을 웅크리고, <span class="purple">당신의 <<breasts_ rul>> 더듬는다</span>. "해야 하는 일이 있다니 애석하군," <<he_ ga>> 말한다.
 	<br><br>
-	You can't stop <<him>> binding your arms and legs together, and tying a gag around your mouth. "Later <<girl>>."
+	당신은 <<him_ i>> 당신의 팔과 다리를 묶고, 입에 재갈을 물리는 것을 막지 못한다. "나중에 봐, <<girl>>."
 	<br><br>
-	<<tearful>> you struggle against the rope. It was a rough job, and you should be able to work free.
+	<<tearful>> 당신은 밧줄을 풀기 위해 몸부림친다. 힘든 과정이지만, 자유롭게 움직일 수 있어야 한다.
 	<br><br>
 	<<endcombat>>
 	<<set $farm_assault.bindings to 3>>
@@ -1416,14 +1416,14 @@ You march into the open.
 <<effects>>
 <<if $enemyarousal gte $enemyarousalmax>>
 	<<ejaculation>>
-	"You'll go far," the <<person1>><<person>> mutters.
+	"넌 장차 크게 되겠어," <<person1>><<person_ i>> 중얼거린다.
 	<<if $enemynomax gte 2>>
-		Bailey's thugs are too dazed and exhausted to continue, <span class="green">and stagger from the field.</span>
+		베일리의 깡패들은 진이 빠지고 멍해진 채로, <span class="green">비틀거리며 들판을 빠져나간다.</span>
 	<<else>>
-		<<Hes>> too dazed and exhausted to continue, <span class="green">and staggers from the field.</span>
+		<<He_ nun>> 진이 빠지고 멍해진 채로, <span class="green">비틀거리며 들판을 빠져나간다.</span>
 	<</if>>
 	<br><br>
-	<<tearful>> you plan your next move.
+	<<tearful>> 당신은 다음 행동을 계획한다.
 	<br><br>
 	<<clotheson>>
 	<<endcombat>>
@@ -1436,14 +1436,14 @@ You march into the open.
 		<</if>>
 	<</for>>
 <<elseif $enemyhealth lte 0>>
-	"Shit," the <<person1>><<person>> says. "Bailey's not gonna be happy."
+	"제기랄," <<person1>><<person_ i>> 말한다. "베일리가 만족스러워하지 않을 거야."
 	<<if $enemynomax gte 2>>
-		<span class="green">Bailey's thugs flee the field,</span> disappearing into the night.
+		<span class="green">베일리의 깡패들은 들판을 벗어나,</span> 밤의 어둠 속으로 사라진다.
 	<<else>>
-		<span class="green"><<He>> flees the field,</span> disappearing into the night.
+		<span class="green"><<He_ nun>> 들판을 벗어나,</span> 밤의 어둠 속으로 사라진다.
 	<</if>>
 	<br><br>
-	<<tearful>> you plan your next move.
+	<<tearful>> 당신은 다음 행동을 계획한다.
 	<br><br>
 	<<clotheson>>
 	<<endcombat>>
@@ -1457,13 +1457,13 @@ You march into the open.
 	<</for>>
 
 <<else>>
-	You fall to the earth, too hurt to continue fighting.
+	당신은 땅에 쓰러진다. 너무 고통스러워서 더는 싸울 수 없다.
 	<br><br>
-	The <<person1>><<person>> crouches over you. "Sorry," <<he>> says. "But this is the way of the world."
+	<<person1>><<person_ i>> 당신 위로 몸을 웅크린다. "유감이야," <<he_ ga>> 말한다. "이게 세상의 이치란다."
 	<br><br>
-	You can't stop <<him>> binding your arms and legs together, and tying a gag around your mouth. "Later <<girl>>."
+	당신은 <<him_ i>> 당신의 팔과 다리를 묶고, 입에 재갈을 물리는 것을 막지 못한다. "나중에 봐, <<girl>>."
 	<br><br>
-	<<tearful>> you struggle against the rope. It was a rough job, and you should be able to work free.
+	<<tearful>> 당신은 밧줄을 풀기 위해 몸부림친다. 힘든 과정이지만, 자유롭게 움직일 수 있어야 한다.
 	<br><br>
 	<<endcombat>>
 	<<set $farm_assault.bindings to 3>>
@@ -1484,9 +1484,9 @@ You march into the open.
 	<<if $bus is $farm_assault.teams[_assault_keys[_s]].location>>
 
 		<<if $farm_assault.teams[_assault_keys[_s]].number gte 2>>
-			You keep to the shadows as you stalk the intruders, waiting for an opening.
+			당신은 틈을 기다리면서, 그림자 속에서 침입자들을 뒤쫓는다.
 		<<else>>
-			You keep to the shadows as you stalk the intruder, waiting for an opening.
+			당신은 틈을 기다리면서, 그림자 속에서 침입자를 뒤쫓는다.
 		<</if>>
 		<br><br>
 
@@ -1494,12 +1494,12 @@ You march into the open.
 		<<if $skulduggerysuccess is 1>>
 
 			<<if $farm_assault.teams[_assault_keys[_s]].number gte 2>>
-				<span class="green">You find one.</span> A <<generate1>><<person1>><<person>> strays too far from <<his>> fellows. You lunge from the dark, and smack <<him>> over the head. <<His>> body slumps to the earth, unconscious.
+				<span class="green">당신은 기회를 잡았다.</span> <<generate1>><<person1>><<person_ i>> <<his_ yi>> 동료들로부터 멀리 벗어나 있다. 당신은 어둠 속에서 돌진하여, <<His_ yi>> 머리를 강타한다. <<He_ nun>> 의식을 잃고 땅바닥에 쓰러진다.
 				<br><br>
 				<<endevent>>
 				<<set $farm_assault.teams[_assault_keys[_s]].number -= 1>>
 			<<else>>
-				<span class="green">You find one.</span> The <<generate1>><<person1>><<person>> stands too close to a hedge, letting you sneak right behind <<him>>. You lunge from the dark, and smack <<him>> over the head. <<His>> body slumps to the earth, unconscious.
+				<span class="green">당신은 기회를 잡았다.</span> <<generate1>><<person1>><<person_ un>> 울타리 가까이에 서 있어서, <<him_ yi>> 바로 뒤까지 몰래 접근할 수 있다. 당신은 어둠 속에서 돌진하여, <<His_ yi>> 머리를 강타한다. <<He_ nun>> 의식을 잃고 땅바닥에 쓰러진다.
 				<br><br>
 				<<endevent>>
 				<<set $farm_assault.teams[_assault_keys[_s]].number -= 1>>
@@ -1520,12 +1520,12 @@ You march into the open.
 				<<else>>
 					<<generate1>><<generate2>>
 				<</if>>
-				A <<person1>><<person>> strays apart from the others, and you make your move, sneaking closer. You lunge from the dark, <span class="red">but the <<person>> spins and catches your arm.</span>
+				<<person1>><<person_ i>> 다른 사람들과 떨어져 있어서, 당신은 슬그머니 다가간다. 당신은 어둠 속에서 돌진하지만, <span class="red"><<person_ i>>가 몸을 돌려 당신의 팔을 붙잡는다.</span>
 				<br><br>
-				"Found the <<girl>>," <<he>> says as <<he>> shunts you away. You hear footsteps from behind.
+				"<<girl_ ul>> 찾았어," <<he_ ga>> 당신을 밀어내며 말한다. 뒤에서 발자국 소리가 들린다.
 				<br><br>
 			<<else>>
-				You keep to the shadows as you stalk the intruder, waiting for an opening.
+				당신은 틈을 기다리면서, 그림자 속에서 침입자를 뒤쫓는다.
 			<</if>>
 
 			<<link [[다음|Farm Assault Fight Bailey]]>><<set $fightstart to 1>><</link>>
@@ -1545,9 +1545,9 @@ You march into the open.
 	<<if $bus is $farm_assault.teams[_assault_keys[_s]].location>>
 
 		<<if $farm_assault.teams[_assault_keys[_s]].number gte 2>>
-			You keep to the shadows as you stalk the intruders, waiting for an opening.
+			당신은 틈을 기다리면서, 그림자 속에서 침입자들을 뒤쫓는다.
 		<<else>>
-			You keep to the shadows as you stalk the intruder, waiting for an opening.
+			당신은 틈을 기다리면서, 그림자 속에서 침입자를 뒤쫓는다.
 		<</if>>
 		<br><br>
 
@@ -1555,12 +1555,12 @@ You march into the open.
 		<<if $skulduggerysuccess is 1>>
 
 			<<if $farm_assault.teams[_assault_keys[_s]].number gte 2>>
-				<span class="green">You find one.</span> A <<generate1>><<person1>><<person>> strays too far from <<his>> fellows. You lunge from the dark, and smack <<him>> over the head. <<His>> body slumps to the earth, unconscious.
+				<span class="green">당신은 기회를 잡았다.</span> <<generate1>><<person1>><<person_ i>> <<his_ yi>> 동료들로부터 멀리 벗어나 있다. 당신은 어둠 속에서 돌진하여, <<His_ yi>> 머리를 강타한다. <<He_ nun>> 의식을 잃고 땅바닥에 쓰러진다.
 				<br><br>
 				<<endevent>>
 				<<set $farm_assault.teams[_assault_keys[_s]].number -= 1>>
 			<<else>>
-				<span class="green">You find one.</span> The <<generate1>><<person1>><<person>> stands too close to a hedge, letting you sneak right behind <<him>>. You lunge from the dark, and smack <<him>> over the head. <<His>> body slumps to the earth, unconscious.
+				<span class="green">당신은 기회를 잡았다.</span> <<generate1>><<person1>><<person_ un>> 울타리 가까이에 서 있어서, <<him_ yi>> 바로 뒤까지 몰래 접근할 수 있다. 당신은 어둠 속에서 돌진하여, <<His_ yi>> 머리를 강타한다. <<He_ nun>> 의식을 잃고 땅바닥에 쓰러진다.
 				<br><br>
 				<<endevent>>
 				<<set $farm_assault.teams[_assault_keys[_s]].number -= 1>>
@@ -1580,17 +1580,17 @@ You march into the open.
 				<<else>>
 					<<generate1>>
 				<</if>>
-				<span class="red">You can't find one.</span> The thugs stay too close together. Attacking one would alert the others.
+				<span class="red">당신은 기회를 잡을 수 없었다.</span> 깡패들은 너무 가까이에 붙어 있다. 한 명을 공격하면, 다른 이가 알아차릴 것이다.
 				<br><br>
 
 				<<link [[다음|Farm Assault]]>><<endevent>><</link>>
 				<br>
 			<<else>>
 				<<generate1>><<person1>>
-				You keep to the shadows as you stalk the intruder, a <<person>>, waiting for an opening. You creep up while <<his>> back is turned, <span class="red">but trip in the dark,</span> stumbling to the ground and alerting <<him>>.
+				당신은 틈을 기다리면서, 그림자 속에서 침입자인 <<person_ ul>> 뒤쫓는다. 당신은 <<his_ ga>> 등을 돌린 사이에 슬금슬금 다가서지만, <span class="red">어둠 속에서 발을 헛디디는 바람에</span> <<him_ i>> 눈치챈다.
 				<br><br>
 
-				<<He>> turns and plants <<his>> feet, though you're not sure <<he>> knows quite where you are.
+				<<He_ nun>> 뒤로 돌아 발을 단단히 내딛는다. <<he_ ga>> 당신의 위치를 확실히 알고 있는 것 같지는 않다.
 				<br><br>
 
 				<<link [[싸운다|Farm Assault Fight]]>><<set $fightstart to 1>><</link>>
@@ -1606,7 +1606,7 @@ You march into the open.
 :: Farm Assault Flight
 <<effects>>
 
-You turn and flee into the darkness.
+당신은 몸을 돌려 어둠 속으로 달아난다.
 <br><br>
 
 <<link [[다음|Farm Assault]]>><<endevent>><</link>>
@@ -1615,32 +1615,32 @@ You turn and flee into the darkness.
 
 :: Farm Assault Pick Alex
 <<effects>>
-You and Alex stalk the intruders, waiting for one to stray too close to the dark.
+당신과 알렉스는 침입자가 어둠에 가까이 다가오기를 기다리며, 그들을 뒤쫓는다.
 <<set _assault_keys to Object.keys($farm_assault.teams)>>
 <<for _s to 0; _s lt _assault_keys.length; _s++>>
 	<<if $bus is $farm_assault.teams[_assault_keys[_s]].location>>
 		<<if $farm_assault.teams[_assault_keys[_s]].type is "bailey">>
 			<<generate1>><<person1>>
-			One, a <<person>>, stands with <<his>> back to a hedge, seeming to think it impenetrable.
+			한 <<person_ i>> 울타리를 등지고 선다. <<he_ nun>> 그것을 뚫고 들어갈 수 없다고 생각하는 것 같다.
 			<br><br>
-			You emerge from the undergrowth to strike, but the <<person>> spins and grasps your arm. <<He>> doesn't notice Alex until it's too late. One blow lays <<him>> on the ground.
+			당신이 공격하기 위해 덤불에서 나오지만, <<person_ un>> 몸을 돌려 당신의 팔을 붙잡는다. <<He_ nun>> 제때 알렉스를 알아차리진 못했고, 한 방에 바닥으로 쓰러진다.
 			<br><br>
-			Alex resists the urge to cheer.
+			알렉스는 환호하고 싶은 충동을 참아낸다.
 			<br><br>
 			<<link [[다음|Farm Assault]]>><<endevent>><</link>>
 			<br>
 		<<else>>
-			They don't seem like they'll play along, until Alex emerges into the light, and taunts them, before vanishing into tall grass.
+			알렉스가 빛 속으로 뛰쳐나가 그들을 약 올린 뒤, 키 큰 풀숲으로 몸을 숨긴다.
 			<br><br>
 			<<generate1>><<person1>>
 			<<if $farm_assault.teams[_assault_keys[_s]].number gte 3>>
-				Two rush after, leaving a <<person>> behind.
+				<<person_ ul>> 뒤에 남기고, 두 명이 달려간다.
 			<<else>>
-				One rushes after, leaving a <<person>> behind.
+				<<person_ ul>> 뒤에 남기고, 한 명이 달려간다.
 			<</if>>
-			Now's your chance. You creep behind <<him>>, and strike. <<He>> doesn't utter a sound as <<he>> falls.
+			지금이 기회다. 당신은 <<him_ yi>> 뒤로 살금살금 다가가, 후려친다. <<He_ nun>> 소리 없이 쓰러진다.
 			<br><br>
-			You regroup with Alex, and plot your next move.
+			당신은 알렉스와 다시 뭉쳐서, 다음 행동을 계획한다.
 			<br><br>
 
 			<<link [[다음|Farm Assault]]>><<endevent>><</link>>
@@ -1653,18 +1653,18 @@ You and Alex stalk the intruders, waiting for one to stray too close to the dark
 :: Farm Assault Charge
 <<effects>>
 
-You charge the intruders, Alex at your side.
+당신은 침입자들에게 달려든다. 알렉스가 당신 옆에 있다.
 <<set _assault_keys to Object.keys($farm_assault.teams)>>
 <<for _s to 0; _s lt _assault_keys.length; _s++>>
 	<<if $bus is $farm_assault.teams[_assault_keys[_s]].location>>
 		<<if $farm_assault.teams[_assault_keys[_s]].number gte 3>>
 			<<generate1>><<generate2>>
-			There are three of them. One splits off to intercept Alex, leaving the <<fullGroup>> to you.
+			그들은 세 명이다. 한 명이 알렉스를 맡기 위해 찢어지고, <<fullGroupPost_ ga>> 당신을 맡는다.
 			<br><br>
 			<<person1>>
 		<<else>>
 			<<generate1>><<person1>>
-			There are two of them. One intercepts Alex, leaving the <<person>> to you.
+			그들은 두 명이다. 한 명이 알렉스를 맡고, <<person_ i>> 당신을 맡는다.
 			<br><br>
 		<</if>>
 		<<if $farm_assault.teams[_assault_keys[_s]].type is "bailey">>
@@ -1681,18 +1681,18 @@ You charge the intruders, Alex at your side.
 :: Farm Assault Overpower
 <<effects>>
 
-<<generate1>><<person1>>You rush the lone intruder, a <<person>>, while Alex circles around.
+<<generate1>><<person1>>알렉스가 주위를 도는 동안, 당신은 혼자뿐인 침입자, <<personPost>>에게 달려든다.
 <<set _assault_keys to Object.keys($farm_assault.teams)>>
 <<for _s to 0; _s lt _assault_keys.length; _s++>>
 	<<if $bus is $farm_assault.teams[_assault_keys[_s]].location>>
 		<<if $farm_assault.teams[_assault_keys[_s]].type is "bailey">>
-			<<He>> turns to face you, planting <<his>> feet. Alex rushes <<him>> from behind. The <<person>> swivels and deflects the blow with <<his>> arms, but this leaves <<him>> open to you. You whack <<him>> over the head, and <<he>> slumps to the ground.<<glove>><<npcincr Alex love 1>>
+			<<He_ nun>> 발을 디디며 당신에게 몸을 돌린다. 알렉스가 <<him_ yi>> 뒤쪽에서 돌진한다. <<person_ un>> 돌아서서 팔로 공격을 막지만, 이것이 <<him_ ul>> 당신에게 노출시킨다. 당신이 <<him_ yi>> 머리를 강하게 치자, <<he_ nun>> 바닥으로 푹 쓰러진다.<<glove>><<npcincr Alex love 1>>
 			<br><br>
 
 			<<link [[다음|Farm Assault]]>><<endevent>><</link>>
 			<br>
 		<<else>>
-			<<He>> turns to face you, planting <<his>> feet. <<He>> notices Alex too late. <<He>> slumps to the ground.<<glove>><<npcincr Alex love 1>>
+			<<He_ nun>> 발을 디디며 당신에게 몸을 돌린다. <<He_ nun>> 알렉스를 너무 늦게 알아차렸고, 바닥으로 푹 쓰러진다.<<glove>><<npcincr Alex love 1>>
 			<br><br>
 			<<link [[다음|Farm Assault]]>><<endevent>><</link>>
 			<br>
@@ -1711,7 +1711,7 @@ You charge the intruders, Alex at your side.
 	<<npcidlegenitals>>
 <</if>>
 
-You hear Alex fighting the other intruder.
+알렉스가 다른 침입자와 싸우는 소리가 들린다.
 <br><br>
 
 <<effects>>
@@ -1732,16 +1732,16 @@ You hear Alex fighting the other intruder.
 <<if $enemyarousal gte $enemyarousalmax>>
 	<<ejaculation>>
 	<<if $enemynomax gte 2>>
-		Remy's thugs are too dazed and exhausted to continue. <span class="green">They stagger from the field.</span>
+		레미의 깡패들은 진이 빠지고 멍해진 채로, <span class="green">비틀거리며 들판을 빠져나간다.</span>
 	<<else>>
-		The <<person1>><<person>> is too dazed and exhausted to continue. <span class="green"><<He>> staggers from the field.</span>
+		<<person1>><<person_ un>> 진이 빠지고 멍해진 채로, <span class="green"><<He>> 비틀거리며 들판을 빠져나간다.</span>
 	<</if>>
 	<br><br>
 
 	<<clotheson>>
 	<<endcombat>>
 	<<npc Alex>><<person1>>
-	<<tearful>> you rush to Alex's aid. You arrive in time to see <<him>> drive the intruder away. <<He>> turns to you, sweaty and triumphant. "We showed em." You don't think <<he>> realises how you subdued yours.
+	<<tearful>> 당신은 알렉스를 도우러 달려간다. 그리고 제시간에 도착하여, <<him_ i>> 침입자를 쫓아내는 장면을 본다. <<He_ nun>> 땀을 흘리며, 승리의 기쁨에 겨운 표정으로 당신을 바라본다. "우리가 본때를 보여줬어." 당신은 당신이 어떻게 그들을 제압했는지 <<he_ ga>> 모를 거라고 생각한다.
 	<br><br>
 	<<link [[다음|Farm Assault]]>><<endevent>><</link>>
 	<br>
@@ -1753,15 +1753,15 @@ You hear Alex fighting the other intruder.
 	<</for>>
 <<elseif $enemyhealth lte 0>>
 	<<if $enemynomax gte 2>>
-		<span class="green">Remy's thugs flee the field,</span> throwing worried glances over their shoulders to make sure you're not pursuing.
+		<span class="green">레미의 깡패들이 들판을 달아난다.</span> 그들은 당신이 쫓아올까 봐, 어깨 너머로 걱정스러운 눈빛을 던진다.		
 	<<else>>
-		<span class="green">The <<person1>><<person>> flees the field,</span> throwing worried glances over <<his>> shoulder to make sure you're not pursing.
+		<span class="green"><<person1>><<person_ i>> 들판을 달아난다.</span> <<He_ nun>> 당신이 쫓아올까 봐, 어깨 너머로 걱정스러운 눈빛을 던진다.
 	<</if>>
 	<br><br>
 	<<clotheson>>
 	<<endcombat>>
 	<<npc Alex>><<person1>>
-	<<tearful>> you rush to Alex's aid. You arrive in time to see <<him>> drive the intruder away. <<He>> turns to you, sweaty and triumphant. "We showed em. No time to rest. Let's go."
+	<<tearful>> 당신은 알렉스를 도우러 달려간다. 그리고 제시간에 도착하여, <<him_ i>> 침입자를 쫓아내는 장면을 본다. <<He_ nun>> 땀을 흘리며, 승리의 기쁨에 겨운 표정으로 당신을 바라본다. "우리가 본때를 보여줬어. 쉴 시간이 없어, 가자."
 	<br><br>
 	<<link [[다음|Farm Assault]]>><<endevent>><</link>>
 	<br>
@@ -1773,18 +1773,18 @@ You hear Alex fighting the other intruder.
 		<</if>>
 	<</for>>
 <<else>>
-	You fall to the earth, too hurt to continue fighting.
+	당신은 땅에 쓰러진다. 너무 고통스러워서 더는 싸울 수 없다.
 	<br><br>
-	The <<person1>><<person>> crouches over you, <span class="purple">and gropes your <<breasts>></span>. "Shame I got a job to do," <<he>> says. <<He>> produces a length of rope.<<gstress>><<stress 6>>
+	<<person1>><<person_ i>> 당신 위로 몸을 웅크리고, <span class="purple">당신의 <<breasts_ rul>> 더듬는다</span>. "해야 하는 일이 있다니 애석하군," <<he_ ga>> 말한다. <<He_ nun>> 밧줄을 길게 늘어뜨린다.<<gstress>><<stress 6>>
 	<br><br>
 
-	"Leave <<phim>> alone!" shouts Alex, rushing over and leaving the other intruder slumped in the mud.
+	"<<phim_ ul>> 내버려 둬!" 알렉스가 소리를 지르며 달려와, 다른 침입자를 진흙에 쓰러뜨린다.
 	<br><br>
-	Alex slams into the <<person>> before <<he>> can rise, and helps you to your feet. <<tearful>> you limp away, supported by Alex at your side.
+	알렉스는 <<person_ i>> 미처 일어나기도 전에 <<he_ rul>> 들이받고, 당신이 일어설 수 있도록 도와준다. <<tearful>> 당신은 알렉스의 도움을 받아 절뚝거리며 떠난다.
 	<<endcombat>>
 	<<clotheson>>
 	<<npc Alex>><<person1>>
-	"That was too dangerous," Alex says once safely hidden away. The intruders don't pursue, perhaps concerned with their own injured. "You can sit out if you need to," <<he>> says. "I've got this."<<ggdom>><<npcincr Alex dom 1>>
+	"너무 위험했어." 안전하게 몸을 숨긴 뒤, 알렉스가 말한다. 침입자들은 그들의 부상을 염려하는지 쫓아오지 않는다. "넌 앉아 있어도 돼," <<he_ ga>> 말한다. "내가 알아서 할게."<<ggdom>><<npcincr Alex dom 1>>
 	<br><br>
 
 	<<link [[다음|Farm Assault]]>><<endevent>><</link>>
@@ -1810,7 +1810,7 @@ You hear Alex fighting the other intruder.
 	<<set $enemyarousalmax *= 1.3>>
 <</if>>
 
-You hear Alex fighting the other intruder.
+알렉스가 다른 침입자와 싸우는 소리가 들린다.
 <br><br>
 
 <<effects>>
@@ -1830,20 +1830,20 @@ You hear Alex fighting the other intruder.
 <<effects>>
 <<if $enemyarousal gte $enemyarousalmax>>
 	<<ejaculation>>
-	"You'll go far," the <<person1>><<person>> mutters.
+	"넌 장차 크게 되겠어," <<person1>><<person_ i>> 중얼거린다.
 	<<if $enemynomax gte 2>>
-		Bailey's thugs are too dazed and exhausted to continue, <span class="green">and stagger from the field.</span>
+		베일리의 깡패들은 진이 빠지고 멍해진 채로, <span class="green">비틀거리며 들판을 빠져나간다.</span>
 	<<else>>
-		<<Hes>> too dazed and exhausted to continue, <span class="green">and staggers from the field.</span>
+		<<He_ nun>> 진이 빠지고 멍해진 채로, <span class="green">비틀거리며 들판을 빠져나간다.</span>
 	<</if>>
 	<br><br>
 
 	<<endcombat>>
 	<<clotheson>>
 	<<npc Alex>><<person1>><<generate2>>
-	<<tearful>> you rush to Alex's side. You find <<him>> wrestling with the remaining intruder, a <<person2>><<person>>. The intruder has the upper hand, until you smack <<him>> over the head from behind.<<person1>><<npcincr Alex dom 1>>
+	<<tearful>> 당신은 알렉스에게 달려간다. 그리고 <<him_ i>> 남은 침입자인 <<person2>><<person_ gwa>> 몸싸움하고 있는 것을 발견한다. 침입자가 우위를 점하고 있었다. 당신이 뒤에서 <<him_ yi>> 머리를 강타하기 전까지는.<<person1>><<npcincr Alex dom 1>>
 	<br><br>
-	"You showed em," Alex says as you help <<him>> to <<his>> feet. You don't think <<he>> realises how you subdued yours.
+	"본때를 보여줬네," 당신의 도움을 받아 자리에서 일어서며, 알렉스가 말한다. 당신은 당신이 어떻게 그들을 제압했는지 <<he_ ga>> 모를 거라고 생각한다.
 	<br><br>
 	<<link [[다음|Farm Assault]]>><<endevent>><</link>>
 	<br>
@@ -1854,19 +1854,19 @@ You hear Alex fighting the other intruder.
 		<</if>>
 	<</for>>
 <<elseif $enemyhealth lte 0>>
-	"Shit," the <<person1>><<person>> says. "Bailey's not gonna be happy."
+	"제기랄," <<person1>><<person_ i>> 말한다. "베일리가 만족스러워하지 않을 거야."
 	<<if $enemynomax gte 2>>
-		<span class="green">Bailey's thugs flee the field,</span> disappearing into the night.
+		<span class="green">베일리의 깡패들은 들판을 벗어나,</span> 밤의 어둠 속으로 사라진다.
 	<<else>>
-		<span class="green"><<He>> flees the field,</span> disappearing into the night.
+		<span class="green"><<He_ nun>> 들판을 벗어나,</span> 밤의 어둠 속으로 사라진다.
 	<</if>>
 	<br><br>
 	<<endcombat>>
 	<<clotheson>>
 	<<npc Alex>><<person1>><<generate2>>
-	<<tearful>> you rush to Alex's side. You find <<him>> wrestling with the remaining intruder, a <<person2>><<person>>. The intruder has the upper hand, until you smack <<him>> over the head from behind.<<person1>><<npcincr Alex dom 1>>
+	<<tearful>> 당신은 알렉스에게 달려간다. 그리고 <<him_ i>> 남은 침입자인 <<person2>><<person_ gwa>> 몸싸움하고 있는 것을 발견한다. 침입자가 우위를 점하고 있었다. 당신이 뒤에서 <<him_ yi>> 머리를 강타하기 전까지는.<<person1>><<npcincr Alex dom 1>>
 	<br><br>
-	"You showed em," Alex says as you help <<him>> to <<his>> feet.
+	"본때를 보여줬네," 당신의 도움을 받아 자리에서 일어서며, 알렉스가 말한다.
 	<br><br>
 	<<link [[다음|Farm Assault]]>><<endevent>><</link>>
 	<br>
@@ -1878,17 +1878,17 @@ You hear Alex fighting the other intruder.
 		<</if>>
 	<</for>>
 <<else>>
-	You fall to the earth, too hurt to continue fighting.
+	당신은 땅에 쓰러진다. 너무 고통스러워서 더는 싸울 수 없다.
 	<br><br>
-	The <<person1>><<person>> crouches over you. "Sorry," <<he>> says. "But this is the way of the world." <<He>> produces a length of rope, and a gag.
+	<<person1>><<person_ i>> 당신 위로 몸을 웅크린다. "유감이야," <<he_ ga>> 말한다. "이게 세상의 이치란다." <<He_ nun>> 밧줄을 길게 늘어뜨리고, 재갈을 꺼낸다.
 	<br><br>
 	<<endcombat>>
 	<<npc Alex>><<person1>><<generate2>>
-	"Don't you dare!" shouts Alex. <<He>> runs closer, but a <<person2>><<person>> tackles <<person1>><<him>> from behind.
+	"네가 감히!" 알렉스가 소리친다. <<He_ ga>> 가까이로 달려오지만, <<person2>><<person_ i>> 뒤에서 <<person1>><<him_ ul>> 막는다.
 	<br><br>
-	"Your friend is spirited. Not a problem. Always bring plenty of rope." You can't stop them binding your arms and legs together, and tying a gag around your mouth. You hear Alex's muffled voice nearby. "Later <<girl>>."
+	"네 친구가 기운이 넘치네. 문제 없어, 밧줄을 항상 넉넉히 들고 다니거든." 당신은 그들이 당신의 팔과 다리를 묶고, 입에 재갈을 물리는 것을 막지 못한다. 근처에서 알렉스의 억눌린 목소리가 들린다. "나중에 봐, <<girl>>."
 	<br><br>
-	<<tearful>> you struggle against the rope. It was a rough job, and you should be able to work free.
+	<<tearful>> 당신은 밧줄을 풀기 위해 몸부림친다. 힘든 과정이지만, 자유롭게 움직일 수 있어야 한다.
 	<br><br>
 	<<endevent>>
 	<<set $farm_assault.bindings to 3>>
@@ -1904,73 +1904,73 @@ You hear Alex fighting the other intruder.
 :: Farm Assault Tower Defend
 <<effects>>
 
-You arrive at the base of the tower. You already hear a struggle at the top. The stairs creak as you climb.
+당신은 망루 밑에 도착한다. 이미 위에서 몸싸움 소리가 들린다. 계단을 올라갈 때마다 삐걱거리는 소리가 난다.
 <br><br>
 <<set _assault_keys to Object.keys($farm_assault.teams)>>
 <<for _s to 0; _s lt _assault_keys.length; _s++>>
 	<<if $bus is $farm_assault.teams[_assault_keys[_s]].location>>
-		You emerge to find <<farm_assault_thugs>> besetting $farm.tower_guard.
+		당신은 <<NPCname_ rul $farm.tower_guard>> 공격하는 <<farm_assault_thugs>> 발견한다.
 		<<endevent>>
 		<<loadNPC 0 "farm_tower_guard">><<person1>>
 
 		<<if $NPCList[0].traits.includes("relaxed")>>
-			"Come on," <<he>> says, backed into a corner, but defiant. "Make it count."
+			"덤벼," <<he_ ga>> 말한다. 구석에 몰려 있는데도 도전적이다. "제대로 해봐."
 		<<elseif $NPCList[0].traits.includes("sociable")>>
-			"I've handled worse than you lot," <<he>> says. "Bring it. See what happens."
+			"너희들보다 더한 것도 겪어봤지." <<he_ ga>> 말한다. "와 봐, 어떻게 되나 보자고."
 		<<elseif $NPCList[0].traits.includes("brooding")>>
-			"Time to earn my pay," <<he>> spits.
+			"돈 벌 시간이군." <<he_ ga>> 침을 뱉는다.
 		<<else>>
-			"I'm popular tonight," <<he>> laughs. "Everyone wants a dance."
+			"오, 오늘 인기 좋은데." <<he_ ga>> 웃는다. "모두 나랑 춤추고 싶어하는군."
 		<</if>>
 		<<endevent>>
 		<br><br>
 		<<if $farm_assault.teams[_assault_keys[_s]].type is "bailey">>
 			<<if $farm_assault.teams[_assault_keys[_s]].number gte 3>>
 				<<generate1>><<generate2>><<person1>><<set $skulduggerydifficulty to 1200>>
-				The three thugs step closer, wary. They haven't noticed you.
+				세 명의 깡패가 경계하며 가까이 다가선다. 그들은 당신을 알아채지 못했다.
 			<<elseif $farm_assault.teams[_assault_keys[_s]].number gte 2>>
 				<<generate1>><<person1>><<set $skulduggerydifficulty to 1000>>
-				The three thugs step closer, wary. They haven't noticed you.
+				세 명의 깡패가 경계하며 가까이 다가선다. 그들은 당신을 알아채지 못했다.
 			<<else>>
 				<<generate1>><<person1>><<set $skulduggerydifficulty to 600>>
-				The thug, a <<person>>, steps closer, wary. <<He>> hasn't noticed you.
+				깡패, <<person_ i>> 경계하며 가까이 다가선다. <<He_ nun>> 당신을 알아채지 못했다.
 			<</if>>
 			<br><br>
 			<<if $skulduggerydifficulty gte 1>>
-				<<link [[Charge|Farm Assault Charge Bailey]]>><</link>>
+				<<link [[달려든다|Farm Assault Charge Bailey]]>><</link>>
 				<br>
 			<</if>>
-			<<link [[Sneak up|Farm Assault Sneak Bailey]]>><</link>><<skulduggerydifficulty>>
+			<<link [[몰래 다가간다|Farm Assault Sneak Bailey]]>><</link>><<skulduggerydifficulty>>
 			<br>
 		<<else>>
 			<<if $farm_assault.teams[_assault_keys[_s]].number gte 3>>
 				<<generate1>><<generate2>><<person1>><<set $skulduggerydifficulty to 800>>
-				The three thugs walk closer, smiling and unthreatened. They haven't noticed you.
+				세 명의 깡패는 전혀 위협받지 않은 듯이, 웃으며 가까이 다가선다. 그들은 당신을 알아채지 못했다.
 			<<elseif $farm_assault.teams[_assault_keys[_s]].number gte 2>><<set $skulduggerydifficulty to 600>>
 				<<generate1>><<person1>>
-				The three thugs step closer, seeming unthreatened. They haven't noticed you.
+				세 명의 깡패는 그다지 위협받지 않은 듯이 가까이 다가선다. 그들은 당신을 알아채지 못했다.
 			<<else>><<set $skulduggerydifficulty to 0>>
 				<<generate1>><<person1>>
-				The thug, a <<person>>, steps closer, wary. <<He>> hasn't noticed you.
+				깡패, <<person_ i>> 경계하며 가까이 다가선다. <<He_ nun>> 당신을 알아채지 못했다.
 			<</if>>
 			<br><br>
 			<<if $skulduggerydifficulty gte 1>>
-				<<link [[Charge|Farm Assault Tower Charge]]>><</link>>
+				<<link [[달려든다|Farm Assault Tower Charge]]>><</link>>
 				<br>
 			<</if>>
-			<<link [[Sneak up|Farm Assault Sneak]]>><</link>><<skulduggerydifficulty>>
+			<<link [[몰래 다가간다|Farm Assault Sneak]]>><</link>><<skulduggerydifficulty>>
 			<br>
 		<</if>>
 	<</if>>
 <</for>>
 
-<<link [[Climb down|Farm Assault]]>><<endevent>><</link>>
+<<link [[내려간다|Farm Assault]]>><<endevent>><</link>>
 <br>
 
 :: Farm Assault Tower Charge
 <<effects>>
 
-You charge the thugs. They spin to face you, giving $farm.tower_guard an opening.
+당신은 깡패들에게 달려든다. 그들은 당신에게 몸을 돌리며, $farm.tower_guard 에게 틈을 보인다.
 <br><br>
 
 <<link [[다음|Farm Assault Tower Fight]]>><<set $fightstart to 1>><</link>>
@@ -1988,7 +1988,7 @@ You charge the thugs. They spin to face you, giving $farm.tower_guard an opening
 	<<npcidlegenitals>>
 <</if>>
 
-$farm.tower_guard fights nearby.
+<<NPCname_ ga $farm.tower_guard>> 근처에서 싸우고 있다.
 <br><br>
 
 <<effects>>
@@ -2009,25 +2009,25 @@ $farm.tower_guard fights nearby.
 <<if $enemyarousal gte $enemyarousalmax>>
 	<<ejaculation>>
 	<<if $enemynomax gte 2>>
-		The thugs stagger away from you. They need a breather, but look ready to continue fighting. Until $farm.tower_guard sends <<his>> colleague plummeting from the tower. They turn and run down the stairs.
+		깡패들이 비틀거리며 멀어진다. 잠시 숨을 돌려야 하긴 해도, 계속 싸울 준비가 되어 있는 것 같다. <<NPCname_ ga $farm.tower_guard>> <<his_ yi>> 동료를 망루에서 떨어뜨리기 전까지는. 그들은 몸을 돌려 계단을 뛰어 내려간다.
 	<<else>>
-		<<He>> staggers away from you. <<He>> needs a breather, but looks ready to continue fighting. Until $farm.tower_guard sends <<his>> colleague plummeting from the tower. <<He>> turns and runs down the stairs.
+		<<He_ nun>> 비틀거리며 멀어진다. 잠시 숨을 돌려야 하긴 해도, 계속 싸울 준비가 되어 있는 것 같다. <<NPCname_ ga $farm.tower_guard>> <<his_ yi>> 동료를 망루에서 떨어뜨리기 전까지는. <<He_ nun>> 몸을 돌려 계단을 뛰어 내려간다.
 	<</if>>
 	<br><br>
-	<<tearful>> you rest against the railing.
+	<<tearful>> 당신은 난간에 기대어 잠시 쉰다.
 	<br><br>
 	<<clotheson>>
 	<<endcombat>>
 
 	<<loadNPC 0 "farm_tower_guard">><<person1>>
 	<<if $NPCList[0].traits.includes("relaxed")>>
-		"That's a strange way to fight," $farm.tower_guard says. "If it works, it works.
+		"싸우는 방식이 특이하네," <<NPCname_ ga $farm.tower_guard>> 말한다. "뭐, 효과가 있었으면 된 거지."
 	<<elseif $NPCList[0].traits.includes("sociable")>>
-		"I've some friends who want to get into sex work," $farm.tower_guard says. "They could learn from you."
+		"섹스로 일하고 싶어하는 친구들이 좀 있는데," <<NPCname_ ga $farm.tower_guard>> 말한다. "그들이 너한테 배울 수 있을 거야."
 	<<elseif $NPCList[0].traits.includes("brooding")>>
-		"That's one way to do it," $farm.tower_guard says. "I don't judge. We survive the way we can."
+		"그것도 하나의 방법이야," <<NPCname_ ga $farm.tower_guard>> 말한다. "난 판단 안 해. 각자 할 수 있는 방법으로 살아가는 거지."
 	<<else>>
-		"Wish you gave me that treatment," $farm.tower_guard laughs.
+		"나한테도 그거 해줬으면 좋겠네," <<NPCname_ ga $farm.tower_guard>> 웃는다.
 	<</if>>
 	<<gstress>><<stress 6>>
 	<<endevent>>
@@ -2045,25 +2045,25 @@ $farm.tower_guard fights nearby.
 
 <<elseif $enemyhealth lte 0>>
 	<<if $enemynomax gte 2>>
-		You smack the <<person1>><<person>> from the tower. $farm.tower_guard's opponent follows suit. The <<person2>><<person>> turns and runs, almost falling down the stairs.
+		당신은 망루에서 <<person1>><<person_ ul>> 후려친다. <<NPCname_ yi $farm.tower_guard>> 상대도 똑같이 맞는다. <<person2>><<person_ un>> 돌아서서 달려가다가, 계단 아래로 떨어질 뻔한다.
 	<<else>>
-		You smack the <<person1>><<person>> from the tower. $farm.tower_guard's opponent follows suit.
+		당신은 망루에서 <<person1>><<person_ ul>> 후려친다. <<NPCname_ yi $farm.tower_guard>> 상대도 똑같이 맞는다.
 	<</if>>
 	<br><br>
-	<<tearful>> you rest on the railing.
+	<<tearful>> 당신은 난간에 기대어 잠시 쉰다.
 	<br><br>
 	<<clotheson>>
 	<<endcombat>>
 
 	<<loadNPC 0 "farm_tower_guard">><<person1>>
 	<<if $NPCList[0].traits.includes("relaxed")>>
-		"Couldn't end any other way," $farm.tower_guard laughs. "We'll send the next ones packing too."
+		"다른 방법으로는 끝낼 수 없었어," <<NPCname_ ga $farm.tower_guard>> 웃는다. "다음 놈들도 똑같이 포장해버리자고."
 	<<elseif $NPCList[0].traits.includes("sociable")>>
-		"That was almost fun," $farm.tower_guard laughs. "Maybe next time we'll break a sweat."
+		"꽤 재밌었어," <<NPCname_ ga $farm.tower_guard>> 웃는다. "다음번에는 아마 땀을 좀 더 흘리겠지."
 	<<elseif $NPCList[0].traits.includes("brooding")>>
-		"Job done, but there might be more coming," $farm.tower_guard says. "Thanks for the assist."
+		"잘 끝났네, 앞으로 더 올지도 몰라." <<NPCname_ ga $farm.tower_guard>> 말한다. "도와줘서 고마워."
 	<<else>>
-		$farm.tower_guard holds out <<his>> hand for a high five. "We showed em," <<he>> says. "Maybe you'll reward me later? A <<if $pronoun is "m">>boy<<else>>girl<</if>> can dream."
+		<<NPCname_ ga $farm.tower_guard>> 하이파이브를 위해 <<his_ yi>> 손을 들어올린다. "해냈어," <<he_ ga>> 말한다. "나중에 상을 주지 않을래? <<if $pronoun is "m">>소년<<else>>소녀<</if>>도 꿈을 꿀 수 있는 법이잖아."
 	<</if>>
 	<br><br>
 	<<endevent>>
@@ -2080,11 +2080,11 @@ $farm.tower_guard fights nearby.
 	<<set $farm_assault.tower to "manned">>
 
 <<else>>
-	You fall against the railing, too hurt to continue fighting.
+	당신은 난간에 부딪쳐 넘어진다. 너무 고통스러워서 더는 싸울 수 없다.
 	<<if $enemynomax gte 2>>
-		The thugs turn their attention to $farm.tower_guard, and rush to their colleague's aid.
+		깡패들은 $farm.tower_guard 에게 주의를 돌리고, 그들의 동료를 돕기 위해 달려간다.
 	<<else>>
-		The <<person1>><<person>> turns <<his>> attention to $farm.tower_guard, and rushes to <<his>> colleague's aid.
+		<<person1>><<person_ un>> $farm.tower_guard 에게 주의를 돌리고, <<his_ yi>> 동료를 돕기 위해 달려간다.
 	<</if>>
 	<br><br>
 	<<endcombat>>
@@ -2093,36 +2093,36 @@ $farm.tower_guard fights nearby.
 	<<set _assault_keys to Object.keys($farm_assault.teams)>>
 	<<for _s to 0; _s lt _assault_keys.length; _s++>>
 		<<if $bus is $farm_assault.teams[_assault_keys[_s]].location>>
-			There's a struggle, until
+			몸싸움 끝에,
 			<<if $farm.tower_guard_skill gte random(1, ($farm_assault.teams[_assault_keys[_s]].number * 500))>>
-				$farm.tower_guard <span class="green">punches one assailant off the tower.</span>
+				<<NPCname_ ga $farm.tower_guard>> <span class="green">공격자 중 한 명을 때려 망루에서 떨어뜨린다.</span>
 				<<if $farm_assault.teams[_assault_keys[_s]].number gte 3>>
-					The other thugs turn and flee down the stairs.
+					다른 깡패들은 몸을 돌려 계단 아래로 달아난다.
 				<<else>>
-					The other thug turns and flees down the stairs.
+					다른 깡패는 몸을 돌려 계단 아래로 달아난다.
 				<</if>>
 				<br><br>
-				$farm.tower_guard helps you to your feet.
+				<<NPCname_ ga $farm.tower_guard>> 당신이 일어서는 것을 돕는다.
 
 				<<if $NPCList[0].traits.includes("relaxed")>>
-					"You alright?" <<he>> asks. "Sit the rest of this out if you need to. I'll keep Alex up to speed."
+					"괜찮아?" <<he_ ga>> 묻는다. "필요하면 앉아서 좀 쉬어. 알렉스를 서두르게 할게."
 				<<elseif $NPCList[0].traits.includes("sociable")>>
-					"Take it easy for a bit," <<he>> says. "Hope the others haven't gotten up to much mischief while I've been distracted."
+					"긴장 풀어," <<he_ ga>> 말한다. "내가 정신 없는 동안 저놈들이 너무 심하게 군 게 아니었으면 좋겠네."
 				<<elseif $NPCList[0].traits.includes("brooding")>>
-					"Don't take so many risks," <<he>> says. "Pace yourself."
+					"너무 많은 위험을 감수하려 하지 마," <<he_ ga>> 말한다. "속도를 좀 조절해."
 				<<else>>
-					"You don't look so good," <<he>> says. "Good thing there are no perverts around to take advantage. Except me, but I'm on your payroll."
+					"안색이 안 좋아 보여," <<he_ ga>> 말한다. "틈을 타 변태짓하려는 놈이 없어서 다행이네, 나 빼고. 그런데 난 당신 월급쟁이잖아."
 				<</if>>
 				<br><br>
-				<<tearful>> you climb down the stairs.
+				<<tearful>> 당신은 계단을 내려간다.
 				<br><br>
 				<<set $farm_assault.tower to "manned">>
 				<<set $farm_assault.teams[_assault_keys[_s]].location to "done">>
 			<<else>>
-				<<farm_assault_thugs>> <span class="red">overpower $farm.tower_guard, and knock <<him>> from the tower.</span> They cheer before rushing down the stairs, paying you no heed.
+				<<farm_assault_thugs>> <span class="red"><<NPCname_ ul $farm.tower_guard>> 제압하여, <<him_ ul>> 망루에서 떨어뜨린다.</span> 그들은 당신을 신경 쓰지 않은 채 환호하다가, 계단을 내려간다.
 				<br><br>
 
-				<<tearful>> you climb to your feet, then down the tower.
+				<<tearful>> 당신은 자리에서 일어나, 망루를 내려간다.
 				<br><br>
 				<<set $farm_assault.teams[_assault_keys[_s]].location to $farm_assault.no.pluck()>>
 				<<set $farm_assault.teams[_assault_keys[_s]].state to "field">>
@@ -2142,7 +2142,7 @@ $farm.tower_guard fights nearby.
 :: Farm Assault Charge Bailey
 <<effects>>
 
-You charge the thugs. They spin to face you, giving $farm.tower_guard an opening.
+당신은 깡패들에게 달려든다. 그들은 당신에게 몸을 돌리며, $farm.tower_guard 에게 틈을 보인다.
 <br><br>
 
 <<link [[다음|Farm Assault Tower Bailey Fight]]>><<set $fightstart to 1>><</link>>
@@ -2162,7 +2162,7 @@ You charge the thugs. They spin to face you, giving $farm.tower_guard an opening
 	<<set $enemyarousalmax *= 1.3>>
 <</if>>
 
-$farm.tower_guard fights nearby.
+<<NPCname_ ga $farm.tower_guard>> 근처에서 싸우고 있다.
 <br><br>
 
 <<effects>>
@@ -2183,25 +2183,25 @@ $farm.tower_guard fights nearby.
 <<if $enemyarousal gte $enemyarousalmax>>
 	<<ejaculation>>
 	<<if $enemynomax gte 2>>
-		The thugs stagger away from you. They need a breather, but look ready to continue fighting. Until $farm.tower_guard sends <<his>> colleague plummeting from the tower. They turn and run down the stairs.
+		깡패들이 비틀거리며 멀어진다. 잠시 숨을 돌려야 하긴 해도, 계속 싸울 준비가 되어 있는 것 같다. <<NPCname_ ga $farm.tower_guard>> <<his_ yi>> 동료를 망루에서 떨어뜨리기 전까지는. 그들은 몸을 돌려 계단을 뛰어 내려간다.
 	<<else>>
-		<<He>> staggers away from you. <<He>> needs a breather, but looks ready to continue fighting. Until $farm.tower_guard sends <<his>> colleague plummeting from the tower. <<He>> turns and runs down the stairs.
+		<<He_ nun>> 비틀거리며 멀어진다. 잠시 숨을 돌려야 하긴 해도, 계속 싸울 준비가 되어 있는 것 같다. <<NPCname_ ga $farm.tower_guard>> <<his_ yi>> 동료를 망루에서 떨어뜨리기 전까지는. <<He_ nun>> 몸을 돌려 계단을 뛰어 내려간다.
 	<</if>>
 	<br><br>
-	<<tearful>> you rest against the railing.
+	<<tearful>> 당신은 난간에 기대어 잠시 쉰다.
 	<br><br>
 	<<clotheson>>
 	<<endcombat>>
 
 	<<loadNPC 0 "farm_tower_guard">><<person1>>
 	<<if $NPCList[0].traits.includes("relaxed")>>
-		"That's a strange way to fight," $farm.tower_guard says. "If it works, it works.
+		"싸우는 방식이 특이하네," <<NPCname_ ga $farm.tower_guard>> 말한다. "뭐, 효과가 있었으면 된 거지."
 	<<elseif $NPCList[0].traits.includes("sociable")>>
-		"I've some friends who want to get into sex work," $farm.tower_guard says. "They could learn from you."
+		"섹스로 일하고 싶어하는 친구들이 좀 있는데," <<NPCname_ ga $farm.tower_guard>> 말한다. "그들이 너한테 배울 수 있을 거야."
 	<<elseif $NPCList[0].traits.includes("brooding")>>
-		"That's one way to do it," $farm.tower_guard says. "I don't judge. We survive the way we can."
+		"그것도 하나의 방법이야," <<NPCname_ ga $farm.tower_guard>> 말한다. "난 판단 안 해. 각자 할 수 있는 방법으로 살아가는 거지."
 	<<else>>
-		"Wish you gave me that treatment," $farm.tower_guard laughs.
+		"나한테도 그거 해줬으면 좋겠네," <<NPCname_ ga $farm.tower_guard>> 웃는다.
 	<</if>>
 	<<gstress>><<stress 6>>
 	<<endevent>>
@@ -2219,25 +2219,25 @@ $farm.tower_guard fights nearby.
 
 <<elseif $enemyhealth lte 0>>
 	<<if $enemynomax gte 2>>
-		You smack the <<person1>><<person>> from the tower. $farm.tower_guard's opponent follows suit. The <<person2>><<person>> smirks, before turning and running down the stairs.
+		당신은 망루에서 <<person1>><<person_ ul>> 후려친다. <<NPCname_ yi $farm.tower_guard>> 상대도 똑같이 맞는다. <<person2>><<person_ un>> 히죽히죽 웃다가, 돌아서서 계단 아래로 달려간다.
 	<<else>>
-		You smack the <<person1>><<person>> from the tower. $farm.tower_guard's opponent follows suit.
+		당신은 망루에서 <<person1>><<person_ ul>> 후려친다. <<NPCname_ yi $farm.tower_guard>> 상대도 똑같이 맞는다.
 	<</if>>
 	<br><br>
-	<<tearful>> you rest on the railing.
+	<<tearful>> 당신은 난간에 기대어 잠시 쉰다.
 	<br><br>
 	<<clotheson>>
 	<<endcombat>>
 
 	<<loadNPC 0 "farm_tower_guard">><<person1>>
 	<<if $NPCList[0].traits.includes("relaxed")>>
-		"Couldn't end any other way," $farm.tower_guard laughs. "We'll send the next ones packing too."
+		"다른 방법으로는 끝낼 수 없었어," <<NPCname_ ga $farm.tower_guard>> 웃는다. "다음 놈들도 똑같이 포장해버리자고."
 	<<elseif $NPCList[0].traits.includes("sociable")>>
-		"That was almost fun," $farm.tower_guard laughs. "Maybe next time we'll break a sweat."
+		"꽤 재밌었어," <<NPCname_ ga $farm.tower_guard>> 웃는다. "다음번에는 아마 땀을 좀 더 흘리겠지."
 	<<elseif $NPCList[0].traits.includes("brooding")>>
-		"Job done, but there might be more coming," $farm.tower_guard says. "Thanks for the assist."
+		"잘 끝났네, 앞으로 더 올지도 몰라." <<NPCname_ ga $farm.tower_guard>> 말한다. "도와줘서 고마워."
 	<<else>>
-		$farm.tower_guard holds out <<his>> hand for a high five. "We showed em," <<he>> says. "Maybe you'll reward me later? A <<if $pronoun is "m">>boy<<else>>girl<</if>> can dream."
+		<<NPCname_ ga $farm.tower_guard>> 하이파이브를 위해 <<his_ yi>> 손을 들어올린다. "해냈어," <<he_ ga>> 말한다. "나중에 상을 주지 않을래? <<if $pronoun is "m">>소년<<else>>소녀<</if>>도 꿈을 꿀 수 있는 법이잖아."
 	<</if>>
 	<br><br>
 	<<endevent>>
@@ -2254,11 +2254,11 @@ $farm.tower_guard fights nearby.
 	<<set $farm_assault.tower to "manned">>
 
 <<else>>
-	You fall against the railing, too hurt to continue fighting.
+	당신은 난간에 부딪쳐 넘어진다. 너무 고통스러워서 더는 싸울 수 없다.
 	<<if $enemynomax gte 2>>
-		The thugs turn their attention to $farm.tower_guard, and rush to their colleague's aid.
+		깡패들은 $farm.tower_guard 에게 주의를 돌리고, 그들의 동료를 돕기 위해 달려간다.
 	<<else>>
-		The <<person1>><<person>> turns <<his>> attention to $farm.tower_guard, and rushes to <<his>> colleague's aid.
+		<<person1>><<person_ un>> $farm.tower_guard 에게 주의를 돌리고, <<his_ yi>> 동료를 돕기 위해 달려간다.
 	<</if>>
 	<br><br>
 	<<endcombat>>
@@ -2267,36 +2267,36 @@ $farm.tower_guard fights nearby.
 	<<set _assault_keys to Object.keys($farm_assault.teams)>>
 	<<for _s to 0; _s lt _assault_keys.length; _s++>>
 		<<if $bus is $farm_assault.teams[_assault_keys[_s]].location>>
-			There's a struggle, until
+			몸싸움 끝에,
 			<<if $farm.tower_guard_skill gte random(1, ($farm_assault.teams[_assault_keys[_s]].number * 1000))>>
-				$farm.tower_guard <span class="green">punches one assailant off the tower.</span>
+				<<NPCname_ ga $farm.tower_guard>> <span class="green">공격자 중 한 명을 때려 망루에서 떨어뜨린다.</span>
 				<<if $farm_assault.teams[_assault_keys[_s]].number gte 3>>
-					The other thugs laugh, then turn and flee down the stairs.
+					다른 깡패들은 웃다가, 몸을 돌려 계단 아래로 달아난다.
 				<<else>>
-					The other thug laughs, then turns and flees down the stairs.
+					다른 깡패는 웃다가, 몸을 돌려 계단 아래로 달아난다.
 				<</if>>
 				<br><br>
-				$farm.tower_guard helps you to your feet.
+				<<NPCname_ ga $farm.tower_guard>> 당신이 일어서는 것을 돕는다.
 
 				<<if $NPCList[0].traits.includes("relaxed")>>
-					"You alright?" <<he>> asks. "Sit the rest of this out if you need to. I'll keep Alex up to speed."
+					"괜찮아?" <<he_ ga>> 묻는다. "필요하면 앉아서 좀 쉬어. 알렉스를 서두르게 할게."
 				<<elseif $NPCList[0].traits.includes("sociable")>>
-					"Take it easy for a bit," <<he>> says. "Hope the others haven't gotten up to much mischief while I've been distracted."
+					"긴장 풀어," <<he_ ga>> 말한다. "내가 정신 없는 동안 저놈들이 너무 심하게 군 게 아니었으면 좋겠네."
 				<<elseif $NPCList[0].traits.includes("brooding")>>
-					"Don't take so many risks," <<he>> says. "Pace yourself."
+					"너무 많은 위험을 감수하려 하지 마," <<he_ ga>> 말한다. "속도를 좀 조절해."
 				<<else>>
-					"You don't look so good," <<he>> says. "Good thing there are no perverts around to take advantage. Except me, but I'm on your payroll."
+					"안색이 안 좋아 보여," <<he_ ga>> 말한다. "틈을 타 변태짓하려는 놈이 없어서 다행이네, 나 빼고. 그런데 난 당신 월급쟁이잖아."
 				<</if>>
 				<br><br>
-				<<tearful>> you climb down the stairs.
+				<<tearful>> 당신은 계단을 내려간다.
 				<br><br>
 				<<set $farm_assault.tower to "manned">>
 				<<set $farm_assault.teams[_assault_keys[_s]].location to "done">>
 			<<else>>
-				<<farm_assault_thugs>> <span class="red">overpower $farm.tower_guard, and knock <<him>> from the tower.</span> They cheer before rushing down the stairs, paying you no heed.
+				<<farm_assault_thugs>> <span class="red"><<NPCname_ ul $farm.tower_guard>> 제압하여, <<him_ ul>> 망루에서 떨어뜨린다.</span> 그들은 당신을 신경 쓰지 않은 채 환호하다가, 계단을 내려간다.
 				<br><br>
 
-				<<tearful>> you climb to your feet, then down the tower.
+				<<tearful>> 당신은 자리에서 일어나, 망루를 내려간다.
 				<br><br>
 				<<set $farm_assault.teams[_assault_keys[_s]].location to $farm_assault.no.pluck()>>
 				<<set $farm_assault.teams[_assault_keys[_s]].state to "field">>
@@ -2316,21 +2316,21 @@ $farm.tower_guard fights nearby.
 <<effects>>
 
 
-You move as fast as you think you can get away with. $farm.tower_guard tries to keep the thugs' attention.
+당신은 문제없다고 생각될 만큼 빠르게 움직인다. <<NPCname_ ga $farm.tower_guard>> 깡패들의 주의를 끌기 위해 노력한다.
 <br><br>
 
 <<skulduggerycheck>>
 <<if $skulduggerysuccess is 1>>
 
-	<span class="green">You make it right up to a <<person>>, and shove.</span> <<He>> cries out in surprise as <<he>> flips over the railing, plummeting from the tower.
+	<span class="green">당신은 성공적으로 <<personPost>>에게 다가가서, 밀어버린다.</span> <<He_ nun>> 놀라서 비명을 지르다가, 난간을 넘어 망루 아래로 곤두박질친다.
 	<<if $enemynomax gte 2>>
-		<<His>> colleagues turn in surprise. $farm.tower_guard seizes the opening, and smacks a <<person2>><<person>> in the face. <<He>> staggers back, then trips and tumbles down the stairs.
+		<<His_ yi>> 동료가 놀라서 돌아본다. 그 틈을 타, <<NPCname_ ga $farm.tower_guard>> <<person2>><<person_ yi>> 얼굴을 가격한다. <<He_ nun>> 비틀거리며 뒤로 물러서다가, 계단에서 굴러 떨어진다.
 		<br><br>
 
-		The remaining thug runs after <<him>>.
+		남은 깡패는 <<him_ ul>> 따라 달아난다.
 		<br><br>
 	<<else>>
-		<<His>> colleague turns in surprise. $farm.tower_guard seizes the opening with a punch, and sends the remaining thug tumbling down the stairs.
+		<<His_ yi>> 동료가 놀라서 돌아본다. 그 틈을 타, <<NPCname_ ga $farm.tower_guard>> 남은 깡패를 계단 아래로 굴러 떨어뜨린다.
 		<br><br>
 	<</if>>
 
@@ -2338,13 +2338,13 @@ You move as fast as you think you can get away with. $farm.tower_guard tries to 
 	<<endevent>>
 	<<loadNPC 0 "farm_tower_guard">><<person1>>
 	<<if $NPCList[0].traits.includes("relaxed")>>
-		"You can think on your feet," $farm.tower_guard says. "I'm glad you were here."
+		"판단이 재빠른데?" <<NPCname_ ga $farm.tower_guard>> 말한다. "네가 여기 있어서 다행이야"
 	<<elseif $NPCList[0].traits.includes("sociable")>>
-		"That's what you get," $farm.tower_guard shouts off the tower. <<He>> turns to you. "Thanks for the backup. I'll get back to spotting."
+		"꼴 좋다!" <<NPCname_ ga $farm.tower_guard>> 망루 밖으로 소리친다. <<He_ ga>> 당신을 돌아본다. "지원 고마워. 난 다시 정찰하러 갈게."
 	<<elseif $NPCList[0].traits.includes("brooding")>>
-		"Nice one," $farm.tower_guard says. "I'll get back to work."
+		"잘했어," <<NPCname_ ga $farm.tower_guard>> 말한다. "난 일로 돌아가겠어."
 	<<else>>
-		"We make a good team," $farm.tower_guard says. "Maybe we'll team up in other ways later." <<He>> laughs."
+		"우린 좋은 팀이야," <<NPCname_ ga $farm.tower_guard>> 말한다. "나중에 다른 방식으로도 팀이 될 수 있을 것 같은데." <<He_ ga>> 웃는다.
 	<</if>>
 	<br><br>
 
@@ -2361,7 +2361,7 @@ You move as fast as you think you can get away with. $farm.tower_guard tries to 
 
 <<else>>
 
-	<span class="red">The floorboards creak,</span> and the thugs swivel to face you. $farm.tower_guard capitalises on the distraction, and punches the closest.
+	<span class="red">마룻바닥이 삐거덕거린다.</span> 깡패들이 당신을 향해 몸을 돌린다. 주의가 산만해진 틈을 타, <<NPCname_ ga $farm.tower_guard>> 가장 가까운 적에게 주먹을 날린다.
 	<br><br>
 
 	<<skulduggeryuse>>
@@ -2374,21 +2374,21 @@ You move as fast as you think you can get away with. $farm.tower_guard tries to 
 :: Farm Assault Sneak Bailey
 <<effects>>
 
-You move as fast as you think you can get away with. $farm.tower_guard tries to keep the thugs' attention.
+당신은 문제없다고 생각될 만큼 빠르게 움직인다. <<NPCname_ ga $farm.tower_guard>> 깡패들의 주의를 끌기 위해 노력한다.
 <br><br>
 
 <<skulduggerycheck>>
 <<if $skulduggerysuccess is 1>>
 
-	<span class="green">You make it right up to a <<person>>, and shove.</span> <<He>> cries out in surprise as <<he>> flips over the railing, plummeting from the tower.
+	<span class="green">당신은 성공적으로 <<personPost>>에게 다가가서, 밀어버린다.</span> <<He_ nun>> 놀라서 비명을 지르다가, 난간을 넘어 망루 아래로 곤두박질친다.
 	<<if $enemynomax gte 2>>
-		<<His>> colleagues turn in surprise. $farm.tower_guard seizes the opening, and smacks a <<person2>><<person>> in the face. <<He>> staggers back, then trips and tumbles down the stairs.
+		<<His_ yi>> 동료가 놀라서 돌아본다. 그 틈을 타, <<NPCname_ ga $farm.tower_guard>> <<person2>><<person_ yi>> 얼굴을 가격한다. <<He_ nun>> 비틀거리며 뒤로 물러서다가, 계단에서 굴러 떨어진다.
 		<br><br>
 
-		The remaining thug flashes you a smile, then runs after <<him>>.
+		남은 깡패가 당신을 향해 웃음을 지어보이고, <<him_ ul>> 따라 달아난다.
 		<br><br>
 	<<else>>
-		<<His>> colleague turns in surprise. $farm.tower_guard seizes the opening with a punch, and sends the remaining thug tumbling down the stairs.
+		<<His_ yi>> 동료가 놀라서 돌아본다. 그 틈을 타, <<NPCname_ ga $farm.tower_guard>> 남은 깡패를 계단 아래로 굴러 떨어뜨린다.
 		<br><br>
 	<</if>>
 
@@ -2396,13 +2396,13 @@ You move as fast as you think you can get away with. $farm.tower_guard tries to 
 	<<endevent>>
 	<<loadNPC 0 "farm_tower_guard">><<person1>>
 	<<if $NPCList[0].traits.includes("relaxed")>>
-		"You can think on your feet," $farm.tower_guard says. "I'm glad you were here."
+		"판단이 재빠른데?" <<NPCname_ ga $farm.tower_guard>> 말한다. "네가 여기 있어서 다행이야"
 	<<elseif $NPCList[0].traits.includes("sociable")>>
-		"That's what you get," $farm.tower_guard shouts off the tower. <<He>> turns to you. "Thanks for the backup. I'll get back to spotting."
+		"꼴 좋다!" <<NPCname_ ga $farm.tower_guard>> 망루 밖으로 소리친다. <<He_ ga>> 당신을 돌아본다. "지원 고마워. 난 다시 정찰하러 갈게."
 	<<elseif $NPCList[0].traits.includes("brooding")>>
-		"Nice one," $farm.tower_guard says. "I'll get back to work."
+		"잘했어," <<NPCname_ ga $farm.tower_guard>> 말한다. "난 일로 돌아가겠어."
 	<<else>>
-		"We make a good team," $farm.tower_guard says. "Maybe we'll team up in other ways later." <<He>> laughs."
+		"우린 좋은 팀이야," <<NPCname_ ga $farm.tower_guard>> 말한다. "나중에 다른 방식으로도 팀이 될 수 있을 것 같은데." <<He_ ga>> 웃는다.
 	<</if>>
 	<br><br>
 
@@ -2419,7 +2419,7 @@ You move as fast as you think you can get away with. $farm.tower_guard tries to 
 
 <<else>>
 
-	<span class="red">The floorboards creak,</span> and the thugs swivel to face you. $farm.tower_guard capitalises on the distraction, and punches the closest.
+	<span class="red">마룻바닥이 삐거덕거린다.</span> 깡패들이 당신을 향해 몸을 돌린다. 주의가 산만해진 틈을 타, <<NPCname_ ga $farm.tower_guard>> 가장 가까운 적에게 주먹을 날린다.
 	<br><br>
 
 	<<skulduggeryuse>>
@@ -2434,20 +2434,20 @@ You move as fast as you think you can get away with. $farm.tower_guard tries to 
 
 <<if !$wraithIntro>>
 	<<set $wraithIntro to true>>
-	You charge at the stranger. They're a beautiful pale figure, with translucent white robes and flowing silver hair. They regard you with angry red eyes, clawing at their own neck. A bizarre, slimy substance leaks wherever they walk.
+	당신은 낯선 이에게 달려든다. 그들은 흐르는 듯한 은빛 머리카락에 반투명한 흰 예복을 입은, 아름다운 창백한 형체다. 그들은 자신의 목을 움켜쥔 채, 분노로 가득 찬 붉은 눈으로 당신을 응시한다. 그들이 걷는 곳마다 기괴하고 끈적거리는 물질이 새어나온다.
 <<elseif !$wraith.seenFarm>>
-	You charge at the stranger. They turn to look at you and chuckle. <span class="red">Their face is a terrible, familiar pale.</span> A bizarre, slimy substance leaks wherever it walks.
+	당신은 낯선 이에게 달려든다. 그들은 고개를 돌려 당신을 보고 빙그레 웃는다. <span class="red">그들의 얼굴은 끔찍하고, 창백한 안색이 낯이 익다.</span> 그들이 걷는 곳마다 기괴하고 끈적거리는 물질이 새어나온다.
 <<else>>
-	You charge at the pale figure. It turns to look at you and chuckles. A bizarre, slimy substance leaks wherever it walks.
+	당신은 창백한 형체에게 달려든다. 그것은 고개를 돌려 당신을 보고 빙그레 웃는다. 그것이 걷는 곳마다 기괴하고 끈적거리는 물질이 새어나온다.
 <</if>>
 <br><br>
 
-"<span class="wraith">Ashes to ashes, eye for an eye. <<pcPetname "Wraith">>.</span>"
+"<span class="wraith">재에는 재, 눈에는 눈. <<pcPetname "Wraith">>.</span>"
 <br><br>
 
 <<generateWraith 1 true>>
 <<initWraith "man" "arms" "abomination">><<startWraith>><<set $wraith.seenFarm to true>>
-An ember crackles at <<his>> finger. <span class="red">The slime begins to spread across the field on its own.</span>
+<<his_ yi>> 손가락에서 불씨가 튀어오른다. <span class="red">슬라임이 스스로 들판을 가로질러 퍼지기 시작한다.</span>
 <br><br>
 
 <<link [[다음|Farm Assault Wraith Fight]]>><<set $fightstart to 1>><<set $phase to 1>><</link>>
@@ -2471,15 +2471,15 @@ An ember crackles at <<his>> finger. <span class="red">The slime begins to sprea
 
 <<if $phase is 1>>
 	<<if $timer gte 8>>
-		<span class="lblue">The slime is thinly spread.</span>
+		<span class="lblue">슬라임이 드문드문 퍼진다.</span>
 	<<elseif $timer gte 6>>
-		<span class="blue">The slime spreads out.</span>
+		<span class="blue">슬라임이 퍼지고 있다.</span>
 	<<elseif $timer gte 4>>
-		<span class="purple">The slime spreads further.</span>
+		<span class="purple">슬라임이 더 멀리 퍼져나간다.</span>
 	<<elseif $timer gte 2>>
-		<span class="pink">The slime almost coats the entire field.</span>
+		<span class="pink">슬라임이 거의 들판 전체를 덮었다.</span>
 	<<else>>
-		<span class="red">The slime covers every inch.</span>
+		<span class="red">슬라임이 사방을 뒤덮었다.</span>
 	<</if>>
 <</if>>
 
@@ -2496,41 +2496,41 @@ An ember crackles at <<his>> finger. <span class="red">The slime begins to sprea
 <<effects>>
 <<if $enemyarousal gte $enemyarousalmax>>
 	<<set _bind to 1>>
-	With a hiss, <span class="green">the embers fizz out</span>.
+	쉿 소리와 함께, <span class="green">불씨가 꺼진다</span>.
 	<<ejaculation>>
 
-	"<span class="wraith">Such spectacular lust.</span>"
+	"<span class="wraith">이 엄청난 욕망.</span>"
 	<<kissWraith>>
 	<br><br>
 
 	<<if $wraith.gen is "arms">>
-		While you're still staggered, <<he>> clasps two of <<his>> extra hands together and forms a translucent, shimmering strand of energy.
+		당신이 여전히 비틀거리는 동안, <<he_ nun>> <<his_ yi>> 여분의 두 손을 꽉 잡고, 반투명하고 반짝이는 에너지 가닥을 만들어낸다.
 	<<else>>
-		While you're still staggered, <<he>> sprouts two additional arms and forms a translucent, shimmering strand of energy.
+		당신이 여전히 비틀거리는 동안, <<he_ nun>> 두 개의 팔이 뻗어 나오게 하여, 반투명하고 반짝이는 에너지 가닥을 만들어낸다.
 	<</if>>
-	The strand flies out of <<his>> hands of its own accord and wraps around you, pinning your arms to your side. <<He>> gently pushes <<his>> foot into your chest, and you fall over.
+	가닥은 저절로 <<his_ yi>> 손에서 날아와 당신을 감싸고, 당신의 팔을 양옆으로 고정시킨다. <<He_ ga>> <<his_ yi>> 발을 부드럽게 당신의 가슴으로 밀어넣자, 당신은 넘어진다.
 	<br><br>
 
-	"<span class="wraith">Cacophony of cinder. Walk the coals that remain, and cover your ears.</span>"
+	"<span class="wraith">재의 불협화음. 남은 석탄 위를 걸어, 네 귀를 막아.</span>"
 	<br><br>
 
-	<<He>> walks away, leaving you in the dirt. You're not sure when you lose sight of <<him>>. <<tearful>> you struggle against the strand of energy. It's gossamer thin, but very strong.
+	<<He_ nun>> 당신을 흙에 남겨둔 채 떠나간다. 당신은 <<him_ i>> 언제 시야에서 사라질지 확신하지 못한다. <<tearful>> 당신은 에너지 가닥을 풀기 위해 몸부림친다. 그것은 거미줄처럼 가늘지만 매우 강하다.
 	<br><br>
 
 	<<endcombat>>
 	<<exitWraith>>
 
 <<elseif $enemyhealth lte 0>>
-	The figure looks down at you in shock as <<he>> staggers backwards. With a hiss, <span class="green">the embers fizz out</span>.
+	형체는 충격에 휩싸인 채, 뒤로 비틀거리며 당신을 내려다본다. 쉿 소리와 함께, <span class="green">불씨가 꺼진다</span>.
 	<<if $wraith.gen is "abomination">>
-		The tentacles drop lifelessly into the dark water.
+		촉수들이 어두운 물속으로 생기를 잃고 떨어진다.
 	<<elseif $wraith.gen is "arms">>
-		<<His>> extra arms fold back in.
+		<<His_ yi>> 여분의 팔들이 다시 접힌다.
 	<</if>>
-	<<His>> head snaps back, and <<he>> dissipates into nothingness with a brief shriek that echoes in your mind. Your ears ring, and you think you hear laughter. "<span class="wraith">You'll reap what you've sown.</span>"
+	<<he_ nun>> 고개를 뒤로 젖히고, 짧은 비명과 함께 허공으로 흩어져 사라진다. <<his_ yi>> 비명이 당신의 마음 속에 메아리친다. 당신의 귀가 울리고, 웃음 소리가 들린다. "<span class="wraith">뿌린 대로 거두게 될 거야.</span>"
 	<br><br>
 
-	<<tearful>> you plan your next move.
+	<<tearful>> 당신은 다음 행동을 계획한다.
 	<br><br>
 
 	<<set $wraith.defeated++>>
@@ -2540,15 +2540,15 @@ An ember crackles at <<his>> finger. <span class="red">The slime begins to sprea
 
 <<elseif $timer lte 0>>
 	<<set _torch to 1>>
-	The pale figure flicks a single spark off its fingertip, onto the slime coating the field. It spreads, and <span class="red">the field bursts into flames.</span> You're not burnt, but the field is torched in front of your eyes. Your heart sinks.
+	창백한 형체가 손가락을 튕기고, 단 하나의 불씨가 들판을 뒤덮은 슬라임 위로 떨어진다. 불꽃이 퍼지며, <span class="red">들판이 화염에 휩싸인다.</span> 화상을 입지는 않았으나, 당신의 눈 앞에서 들판이 횃불처럼 타들어간다. 심장이 내려앉는다.
 	<<control -10>><<stress 12>><<trauma 6>><<lcontrol>><<ggstress>><<gtrauma>>
 	<br><br>
 
-	"<span class="wraith">Does it hurt, being ripped away in front of you?</span>" The pale figure grabs your face while you're distracted.
+	"<span class="wraith">눈앞에서 찢겨나가는 게, 괴로워?</span>" 당신이 혼란스러워하자, 창백한 형체가 당신의 얼굴을 붙잡는다.
 	<<set $wraith.gen to "man">><<kissWraith>>
 	<br><br>
 
-	<<He>> walks away, leaving you standing in the scorched field. You're not sure when you lose sight of <<him>>. <<tearful>> you plan your next move.
+	<<He_ nun>> 불타오르는 들판에 서있는 당신을 두고 떠나간다. 당신은 <<him_ i>> 언제 시야에서 사라질지 확신하지 못한다. <<tearful>> 당신은 다음 행동을 계획한다.
 	<br><br>
 
 	<<clotheson>>
@@ -2557,25 +2557,25 @@ An ember crackles at <<his>> finger. <span class="red">The slime begins to sprea
 
 <<else>>
 	<<set _bind to 1>><<set _torch to 1>>
-	You fall to the earth, too hurt to continue fighting.
+	당신은 땅에 쓰러진다. 너무 고통스러워서 더는 싸울 수 없다.
 	<br><br>
 
 	<<if $wraith.gen is "arms">>
-		The pale figure clasps two of <<his>> extra hands together and forms a translucent, shimmering strand of energy.
+		창백한 형체는 <<his_ yi>> 여분의 두 손을 꽉 잡고, 반투명하고 반짝이는 에너지 가닥을 만들어낸다.
 	<<else>>
-		The pale figure sprouts two additional arms and forms a translucent, shimmering strand of energy.
+		창백한 형체는 두 개의 팔이 뻗어 나오게 하여, 반투명하고 반짝이는 에너지 가닥을 만들어낸다.
 	<</if>>
-	The strand flies out of <<his>> hands of its own accord and wraps around you, pinning your arms to your side. <<He>> gently pushes <<his>> foot into your chest, and you fall over.
+	가닥은 저절로 <<his_ yi>> 손에서 날아와 당신을 감싸고, 당신의 팔을 양옆으로 고정시킨다. <<He_ ga>> <<his_ yi>> 발을 부드럽게 당신의 가슴으로 밀어넣자, 당신은 넘어진다.
 	<br><br>
 
-	"<span class="wraith">Cacophony of cinder. Walk the coals that remain, and cover your ears.</span>"
+	"<span class="wraith">의 불협화음. 남은 석탄 위를 걸어, 네 귀를 막아.</span>"
 	<br><br>
 
-	The pale figure flicks a single spark off its fingertip, onto the slime coating the field. It spreads, and <span class="red">the field bursts into flames.</span> You're not burnt, but the field is torched in front of your eyes. You struggle and scream.
+	창백한 형체가 손가락을 튕기고, 단 하나의 불씨가 들판을 뒤덮은 슬라임 위로 떨어진다. 불꽃이 퍼지며, <span class="red">들판이 화염에 휩싸인다.</span> 화상을 입지는 않았으나, 당신의 눈 앞에서 들판이 횃불처럼 타들어간다. 당신은 몸부림치고 비명 지른다.
 	<<control -10>><<stress 12>><<trauma 6>><<lcontrol>><<ggstress>><<gtrauma>>
 	<br><br>
 
-	The pale figure walks away, leaving you in the dirt. You're not sure when you lose sight of <<him>>. <<tearful>> you struggle against the strand of energy. It's gossamer thin, but very strong.
+	창백한 형체는 당신을 흙에 남겨둔 채 떠나간다. 당신은 <<him_ i>> 언제 시야에서 사라질지 확신하지 못한다. <<tearful>> 당신은 에너지 가닥을 풀기 위해 몸부림친다. 그것은 거미줄처럼 가늘지만 매우 강하다.
 	<br><br>
 
 	<<endcombat>>

--- a/game/overworld-plains/loc-farm/widgets.twee
+++ b/game/overworld-plains/loc-farm/widgets.twee
@@ -2711,38 +2711,38 @@
 <</widget>>
 
 <<widget "farm_assault_intro">>
-	<span class="green">Alex is ready to fight.</span>
+	<span class="green">알렉스는 싸울 준비가 됐다.</span>
 	<br>
 	<<if $farm.kennel gte 1>>
-		<span class="green">The hounds are trained and ready to defend their masters.</span>
+		<span class="green">사냥개들은 훈련되었고, 그들의 주인을 지킬 준비가 됐다.</span>
 	<<else>>
-		<span class="blue">The hounds are ready to defend the farm, but don't have any special training.</span>
+		<span class="blue">사냥개들은 농장을 지킬 준비가 되었지만, 특별한 훈련은 받지 않았다.</span>
 	<</if>>
 	<br>
 	<<if $farm.tower gte 2>>
 		<<if $farm.tower_guard>>
-			<span class="green">The watchtower and searchlight are operated by $farm.tower_guard,</span> with <<guard_skill_text "tower">> security skill.
+			<span class="green"><<NPCname_ ga $farm.tower_guard>> 망루와 탐조등을 담당한다.</span> 그의 보안 스킬은 <<guard_skill_text "tower">>등급이다.
 		<<else>>
-			<span class="red">The watchtower is empty,</span> but you could use it to get a better view.
+			<span class="red">망루는 비어 있다.</span> 하지만 당신은 더 나은 시야를 위해 그것을 이용할 수 있다.
 		<</if>>
 	<<elseif $farm.tower gte 1>>
 		<<if $farm.tower_guard>>
-			<span class="teal">The watchtower is operated by $farm.tower_guard,</span> with <<guard_skill_text "tower">> security skill.
+			<span class="teal"><<NPCname_ ga $farm.tower_guard>> 망루를 담당한다.</span> 그의 보안 스킬은 <<guard_skill_text "tower">>등급이다.
 		<<else>>
-			<span class="red">The watchtower is empty,</span> but you could use it to get a better view.
+			<span class="red">망루는 비어 있다.</span> 하지만 당신은 더 나은 시야를 위해 그것을 이용할 수 있다.
 		<</if>>
 	<</if>>
 	<br>
 	<<if $farm.wall gte 4>>
-		<span class="green">The barbed metal fence around the farm is unclimbable. Attackers will need to cut their way in, which will take a while.</span>
+		<span class="green">농장 주변의 철조망은 타고 오를 수 없다. 공격자들은 그것들을 잘라내야 하고, 그것은 시간이 걸릴 것이다.</span>
 	<<elseif $farm.wall gte 3>>
-		<span class="teal">The tall metal fence around the farm will greatly slow attackers.</span>
+		<span class="teal">농장 주변의 높은 금속 울타리는 공격자들의 속도를 크게 늦출 것이다.</span>
 	<<elseif $farm.wall gte 2>>
-		<span class="lblue">The reinforced wall around the farm will slow attackers.</span>
+		<span class="lblue">농장 주변의 보강된 벽은 공격자들의 속도를 늦출 것이다.</span>
 	<<elseif $farm.wall gte 1>>
-		<span class="blue">The wall around the farm will slightly slow attackers.</span>
+		<span class="blue">농장 주변의 벽은 공격자들의 속도를 약간 늦출 것이다.</span>
 	<<else>>
-		<span class="purple">The wall and fence enclosing the farm provide a meager barrier.</span>
+		<span class="purple">농장을 둘러싸고 있는 벽과 울타리는 방어력이 변변찮다.</span>
 	<</if>>
 	<br><br>
 <</widget>>


### PR DESCRIPTION
### loc-farm/assault.twee

1. 미번역: 987-1022

2. 조사 매크로가 필요할 것으로 보이나, 능력 문제로 조사 없이 번역만 해둠.
> farm_assault_thugs (line 771)
> farm_assault_location (line 741)
> farm_assault_intruders (line 1059)

3. 조사 매크로 없이 사용할 경우(-에게)의 용법이 헷갈려 미번역 상태로 둠.
> $farm.tower_guard (line 1974, 2146, 2086, 2088, 2260, 2262)