### PR TITLE
loc-cabin\punishment.twee 미번역 부분 1149부터 번역

### DIFF
--- a/game/overworld-forest/loc-cabin/punishment.twee
+++ b/game/overworld-forest/loc-cabin/punishment.twee
@@ -1151,18 +1151,18 @@
 <<npc Eden>><<person1>>
 
 <<if $edenFluidsCheck is "run">> /* after run, return to the cabin */
-    Nervous, you walk into the clearing. Eden may still be mad. 
+    긴장한 채로, 당신은 개간지로 걸어 들어간다. 에덴은 여전히 화가 났을지도 모른다.
     <br><br>
-    You don't see <<him>> at first, not until you hear a twig snap behind you. 
+    처음에 당신은 뒤에서 잔가지 부러지는 소리가 들릴 때까지 <<him_ rul>> 보지 못한다.
     <<if $goocount gt 0 or $semencount gt 0>> /* with fluids on you */
-        "You're still covered in all of that. It's disgusting."<<npcincr Eden love -5>><<llllove>>
+        "아직도 네가 온통 그딴 것에 덮여있다니. 역겹기 짝이 없어."<<npcincr Eden love -5>><<llllove>>
         <br><br>
-        You see Eden reaching for you in the corner of your eye.
+        당신의 시야 한편에서 에덴이 당신에게 손을 뻗는다.
 
     <<else>> /* clean */
-        "Just because you washed, doesn't mean I forgot."
+        "네가 씻었다고 해서 내가 잊은 건 아니야."
         <br><br>
-        You see Eden reaching for you from the corner of your eye.
+        당신의 시야 한편에서 에덴이 당신에게 손을 뻗는다.
 
         <<set $edenFluidsCheck to "clean">>
     <</if>>
@@ -1174,54 +1174,54 @@
         <</if>>
     <</for>>
 
-    You burst through the trees into the clearing. Eden pauses <<his>> task to look at you. <<He>> does a double take, and  <<his>> face screws up when <<he>> sees the fluids on your _bodyFluids. <<stress 6>><<gstress>>
+    당신은 나무 사이를 뚫고 개간지로 들어간다. 에덴은 잠깐 <<his_ ga>> 하던 일을 멈추고 당신을 본다. <<He_ nun>> 깜짝 놀라 당신을 다시 쳐다보더니, 당신의 _bodyFluids에 묻은 액체를 알아채고 표정을 일그러트린다. <<stress 6>><<gstress>>
     <br><br>
-    Eden marches towards you, snarling. "Who touched you?"<<npcincr Eden love -5>><<llllove>>
+    에덴은 으르렁거리며 당신에게 성큼성큼 다가온다. "누가 널 만졌어?"<<npcincr Eden love -5>><<llllove>>
 <</if>>
 
 <br><br>
-<<link [[Run|Eden Fluids Punishment 2]]>><<set $phase to 1>><<npcincr Eden love -5>><<npcincr Eden dom -1>><</link>><<llllove>><<ldom>><<athleticsdifficulty 650 900>>
+<<link [[도망친다|Eden Fluids Punishment 2]]>><<set $phase to 1>><<npcincr Eden love -5>><<npcincr Eden dom -1>><</link>><<llllove>><<ldom>><<athleticsdifficulty 650 900>>
 <br>
-<<link [[Stay still|Eden Fluids Punishment 2]]>><<set $phase to 0>><<npcincr Eden dom 1>><</link>><<gdom>>
+<<link [[가만히 있는다|Eden Fluids Punishment 2]]>><<set $phase to 0>><<npcincr Eden dom 1>><</link>><<gdom>>
 
 :: Eden Fluids Punishment 2
 <<set $outside to 1>><<set $location to "cabin">><<effects>><<set $bus to "edenclearing">>
 <<if $phase is 0>> /* Stay still */
     <<if $edenFluidsCheck is "run" or $edenFluidsCheck is "clean">>
-        Eden's hand is rough as <<he>> grabs your arm, the <<nnpc_title "Eden">> grasping so hard <<his>> nails dig into your skin. <<pain 2>><<gpain>>
+        에덴의 손은 거칠게 당신의 팔을 붙잡고, <<nnpc_title_ un "Eden">> <<his_ yi>> 손톱이 당신의 피부를 파고들 정도로 세게 움켜쥔다. <<pain 2>><<gpain>>
     <<else>>
-        You shiver as Eden comes closer, jumping when <<his>> hand grabs your arm. <<He>> examines you closer, <<his>> lip curling in disgust. 
+        당신은 에덴이 가까이 다가오자 몸을 떨며, <<his_ yi>> 손이 당신의 팔을 잡자 움찔한다. <<He_ nun>> 당신을 더 가까이서 살피고, <<his_ yi>> 입술이 혐오감에 비틀린다.
         <br><br>
-        "I've been too gentle with you."
+        "내가 너한테 지나치게 상냥했던 모양이야."
     <</if>>
         <br><br>
         <<link [[다음|Eden Fluids Punishment 3]]>><</link>>
 <<else>> /* Run */
     <<if $edenFluidsCheck is "run">>
-        Not wanting to be hurt again, you turn and begin sprinting into the forest. 
+        다시 다치고 싶지 않아, 당신은 돌아서서 숲속으로 질주하기 시작했다.
     <<else>>
-        Scared of what Eden may do, you turn and begin sprinting into the forest. 
+        에덴이 무슨 짓을 할까 두려워, 당신은 돌아서서 숲속으로 질주하기 시작했다.
     <</if>>
-	<<He>> yells after you, insisting that you come back. You can hear <<him>> running after you. <<stress 6>><<gstress>>
+	<<He_ ga>> 당신에게 외치며, 돌아오라고 한다. 당신은 <<him_ ga>> 뒤쫓는 소리를 들을 수 있다. <<stress 6>><<gstress>>
     <br><br>
     <<if $athleticsSuccess>>
-        You run for a while, getting scratched as you push past branches. <<gpain>><<pain 2>>
+        당신은 달리는 동안, 나뭇가지를 밀치다 긁힌다. <<gpain>><<pain 2>>
         <br><br>
-        Eventually, Eden's yelling gets quieter until it stops completely. <span class="green">You've lost <<him>>.</span> 
+        마침내, 에덴의 외침은 차츰 더 작아지다 완전히 멈춘다. <span class="green">당신은 <<him_ 에게서>> 벗어났다.</span> 
         <br><br>
-        It takes a while to catch your breath as the adrenaline runs through you. <span class="red">Returning to the cabin may be dangerous.</span>
+        아드레날린이 솟구쳐 숨을 고르는 데에 시간이 걸린다. <span class="red">오두막으로 돌아가는 것은 위험할지도 모른다.</span>
         <br><br>
         <<link [[다음|Forest]]>><<set $edenFluidsCheck to "run">><<endevent>><<set $eventskip to 1>><<set $forest to random(50, 75)>><</link>>
 	<<else>>
-        You push yourself as hard as you can, <span class="red">but Eden catches up.</span> <<He>> tackles you to the ground and the air leaves your lungs as you crash into the dirt. <<pain 4>><<gpain>>
+        당신은 할 수 있는 한 스스로를 밀어붙이지만, <span class="red">에덴은 따라잡는다.</span> <<He_ nun>> 당신을 땅으로 엎어트리고 당신이 흙바닥에 부딪히자 당신의 폐에서 공기가 빠져나간다. <<pain 4>><<gpain>>
         <br><br>
         <<if $edenFluidsCheck is "clean">>
-            "You're such an ungrateful brat," <<he>> growls as <<he>> punches you in the back of the head. <<pain 4>><<gpain>>
+            "넌 정말 배은망덕한 애새끼야," <<he_ ga>> 으르렁거리며 당신의 뒤통수를 주먹으로 친다. <<pain 4>><<gpain>>
         <<else>>
-            "<<if $edenFluidsCheck is "run">>I never thought that you'd be a cheat,<<else>>After all I've done, this is the thanks I get?<</if>>" Eden growls as <<he>> punches you. <<pain 8>><<ggpain>>
+            "<<if $edenFluidsCheck is "run">>난 네가 바람피울 거라곤 생각조차 하지 않았는데,<<else>>내가 한 모든 일에 대해 고작 이게 내가 받는 감사야?<</if>>" 에덴이 으르렁거리며 당신에게 주먹을 날린다. <<pain 8>><<ggpain>>
         <</if>>
         <br><br>
-        Dizzy from the punch, you can't fight <<him>> as <<he>> hauls you onto <<his>> shoulder. When you come back to your senses, Eden spanks you every time you attempt to struggle. Soon enough you return to the cabin.
+        타격에 현기증이 나서, <<he_ ga>> 당신을 어깨 위로 집어 들어도 맞서 싸울 수 없다. 당신이 정신을 차리자, 에덴은 당신이 몸부림치려고 시도할 때마다 엉덩이를 찰싹 때린다. 곧 당신은 오두막으로 돌아온다.
         <br><br>
         <<link [[다음|Eden Fluids Punishment 3]]>><</link>>
     <</if>>
@@ -1231,35 +1231,35 @@
 <<set $outside to 0>><<set $location to "cabin">><<effects>><<set $bus to "edencabin">>
 <<if $edenFluidsCheck is "clean">>
     <<if $phase is 0>> /* Stay still */
-        Eden grasps your hand and pulls you back into the cabin. <<He>> flings you to the floor as <<he>> reaches behind a wardrobe to get something. It's the cage. <<stress 6>><<gstress>>
+        에덴은 당신의 손을 움켜쥐고 다시 오두막 안으로 끌어당긴다. <<He_ nun>> 무언가를 얻으러 옷장 뒤로 손을 뻗으면서 당신을 바닥에 내동댕이 친다. 그건 우리다. <<stress 6>><<gstress>>
     <<else>> /* Run */
-        You're led inside and dropped onto the hardwood floor as Eden reaches behind a wardrobe. <<He>> brings out the cage. <<stress 6>><<pain 4>><<gstress>><<gpain>>
+        당신은 안으로 끌려가고 에덴이 옷장 뒤로 손을 뻗으면서 딱딱한 나무 바닥으로 내팽개쳐진다. <<He_ nun>> 우리를 꺼낸다. <<stress 6>><<pain 4>><<gstress>><<gpain>>
     <</if>>
 <<else>>
     <<if $phase is 0>> /* Stay still */
-        Eden pulls you towards the spring behind the cabin, <<his>> grip never loosening. When you get to the edge, <<he>> pushes you in before you can ask <<him>> what <<he>> is doing.
+        에덴은 당신을 오두막 뒤편의 샘 쪽으로 끌어당기며, <<his_ yi>> 손아귀는 절대 풀리지 않는다. 당신이 주변에 도착하자, <<he_ ga>> 무엇을 하는지 묻기도 전에 <<he_ nun>> 당신을 밀어 넣는다.
         <br><br>
     <<else>> /* Run */
-        Eden doesn't stop as <<he>> walks up to the cabin, instead walking past to the spring behind. "<<if $edenFluidsCheck is "run">>I hate how you smell right now.<<else>>You're not coming inside until you're clean.<</if>>"
+        에덴은 오두막으로 가는 동안 멈추지 않고, 뒤에 있는 샘을 향해 걷는다. "<<if $edenFluidsCheck is "run">>지금 네 냄새가 정말 싫어.<<else>>네가 깨끗해질 때까진 안으로 못 들어올 줄 알아.<</if>>"
         <br><br>
-        There is no warning when Eden throws you into the spring.
+        에덴이 당신을 샘 속으로 던질 때 아무런 경고도 없었다.
     <</if>>
     <<if $edenspring gte 4>> /* spring is clean */
-        The water is a shock, and panic sets in as Eden grabs your hair and keeps you under for a few seconds.
+        물은 충격을 주고, 에덴이 당신의 머리카락을 붙잡고 몇 초간 처박자 공황 상태에 빠진다.
     <<else>>
-        The water is a shock, and the debris hurts as a hand grasps the back of your neck, keeping you down for a few seconds. <<pain 2>><<gpain>>
+        물은 충격을 주고, 손이 당신의 목덜미를 움켜잡고 몇 초간 처박자 잔해가 아픔을 준다. <<pain 2>><<gpain>>
     <</if>>
     <br><br>
-    Eden pulls you back up, letting you gasp for air as <<he>> begins to strip you of your clothes.
+    에덴이 당신을 다시 끌어올리자, 당신은 숨을 헐떡이고 <<he_ nun>> 당신의 옷을 벗기기 시작한다.
     <<wash>><<ruined>>
     <br><br>
-    <<Hes>> quiet as <<he>> roughly washes you with a rag from <<his>> belt. It smells like <<him>>, you think it's the towel <<he>> used to wipe sweat away after working. <<npcincr Eden lust 5>><<glust>>
+    <<Hes_ nun>> 침묵하며 <<his_ yi>> 벨트에 있는 해진 천으로 당신을 난폭하게 씻긴다. 그건 <<him_ yi>> 냄새가 나서, 당신은 <<he_ ga>> 일한 뒤에 땀을 닦았던 수건이라고 생각한다. <<npcincr Eden lust 5>><<glust>>
     <br><br>
-    "I'm hurt," <<he>> finally says. <<His>> tone is still angry. 
+    "상처받았어," <<he_ ga>> 마침내 말한다. <<His_ yi>> 어조는 여전히 화가 났다.
     <br><br>
-    When you're clean, Eden grasps your hand and pulls you back into the cabin. <<He>> flings you to the floor as <<he>> reaches behind a wardrobe to get something. It's the cage. <<stress 6>><<gstress>>
+    당신이 깨끗해 지자, 에덴은 당신의 손을 움켜쥐고 다시 오두막 안으로 끌어당긴다. <<He_ nun>> 무언가를 얻으러 옷장 뒤로 손을 뻗으면서 당신을 바닥에 내동댕이 친다. 그건 우리다. <<stress 6>><<gstress>>
     <br><br>
-    "You obviously need more time to think about what you've done."
+    "분명히 넌 네가 저지른 일에 대해 생각할 시간이 더 필요하겠지."
 <</if>>
 
 <<set $edenFluidsCheck to "Eden">>
@@ -1271,11 +1271,11 @@
 :: Eden Fluids Punishment 4
 <<effects>>
 <<if $phase is 0>> /* Accept your punishment */
-    Eden is right. You betrayed <<his>> trust. You should accept your punishment. 
+    에덴의 말이 맞다. 당신은 <<his_ yi>> 신뢰를 배신했다. 당신은 당신의 처벌을 받아들여야 한다.
     <br><br>
-    You crawl into the cage as Eden holds the gate open, flinching as <<he>> slams it shut. 
+    당신은 에덴이 문을 열고 있는 동안 우리 안으로 기어 들어가고, <<he_ ga>> 문을 쾅 닫자 움찔한다.
     <br><br>
-    "Don't go thinking that I'll be kinder just because you're behaving now."
+    "네가 지금 얌전하게 군다고 해서 내가 더 친절해질 거라 생각하지 마."
 
 	<<ruined>>
     <<unset $edenCagedEscape>>
@@ -1287,21 +1287,21 @@
     <<link [[다음|Eden Caged]]>><<set $phase to 0>><</link>>
 <<else>> /* Run */
     <<if $athleticsSuccess>>
-        Not wanting to be locked away, you bolt out of the door. Eden curses before giving chase. You keep going into the forest, not looking back.
+        갇히고 싶지 않아, 당신은 문밖으로 뛰쳐나간다. 에덴이 추격하기 전에 욕지거리를 한다. 당신은 뒤도 돌아보지 않고, 계속해서 숲으로 들어간다.
         <br><br>
-        You run for a while, getting scratched as you push past branches. <<gpain>><<pain 2>>
+        당신은 달리는 동안, 나뭇가지를 밀치다 긁힌다. <<gpain>><<pain 2>>
         <br><br>
-        Eventually, Eden's yelling gets quieter until it stops completely. <span class="green">You've lost <<him>>.</span> 
+        마침내, 에덴의 외침은 차츰 더 작아지다 완전히 멈춘다. <span class="green">당신은 <<him_ 에게서>> 벗어났다.</span> 
         <br><br>
-        It takes a while to catch your breath as the adrenaline runs through you. <span class="red">Returning to the cabin may be dangerous.</span>
+        아드레날린이 솟구쳐 숨을 고르는 데에 시간이 걸린다. <span class="red">오두막으로 돌아가는 것은 위험할지도 모른다.</span>
         <br><br>
         <<link [[다음|Forest]]>><<set $edenCagedEscape to true>><<endevent>><<set $eventskip to 1>><<set $forest to random(50, 75)>><</link>>
 	<<else>>
-        Not wanting to be locked away, you try to bolt for the door. <span class="red">Eden is quicker than you are.</span> <<He>> grips your hair, pulling you back towards the cage. 
+        갇히고 싶지 않아, 당신은 문으로 뛰쳐나가려 한다. <span class="red">에덴은 당신보다 빠르다.</span> <<He_ nun>> 당신의 머리채를 잡고, 당신을 우리 쪽으로 끌어당긴다.
         <br><br>
-        "You better learn well from this."
+        "이번 일로 잘 배우는 편이 좋을 거야."
         <br><br>
-        Eden throws you into the cage, locking it with a padlock.
+        에덴은 당신을 우리 안에 던져 넣고, 자물쇠로 잠근다.
 
 		<<ruined>>
         <<unset $edenCagedEscape>>


### PR DESCRIPTION
기존 번역을 참고하여 번역했으나 어색한 부분이 있다면 교정 부탁드립니다.
또한 1191의 <<nnpc_title_ un "Eden">>은 한글화 가이드의 옵션이 붙은 위젯에 EasyPost 적용하기 문단을 보고 했으나 기존에 번역된 <<nnpc_titlePost "Eden" "조사">>와 형식이 다릅니다. 이게 문제가 될는지요?